### PR TITLE
Bump golangci-lint to v1.22.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ run:
 linters:
   enable-all: true
   disable:
+    - gomnd
     - stylecheck
     - wsl
     - whitespace

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -9,7 +9,7 @@ gopath="$(go env GOPATH)"
 if ! [[ -x "$gopath/bin/golangci-lint" ]]; then
 	echo >&2 'Installing golangci-lint'
 	curl --silent --fail --location \
-		https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$gopath/bin" v1.21.0
+		https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$gopath/bin" v1.22.2
 fi
 
 # configured by .golangci.yml


### PR DESCRIPTION
There is a new linter: gomnd
It's a magic number detector but it's
disabled due to its less benefits and multiple
false positives for hardcoded numbers in tests.
