### PR TITLE
do not send "null" as body in request without body

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,8 +89,10 @@ func (c *Client) newRequest(method, path string, params url.Values, data interfa
 	}
 
 	c.setHeaders(r)
-
 	switch t := data.(type) {
+	case nil:
+		r.Body = nil
+
 	case easyjson.Marshaler:
 		b, err := easyjson.Marshal(t)
 		if err != nil {


### PR DESCRIPTION
currently requests with nil body always set the body to 'null'

example generated body for a get request
```
GET /channels?api_key=892s22ypvt6m&payload=%7B%22watch%22%3Afalse%2C%22state%22%3Atrue%2C%22presence%22%3Afalse%2C%22filter_conditions%22%3A%7B%22limit%22%3A1%2C%22id%22%3A%22222656533%22%7D%7D HTTP/1.1
Host: localhost:9000
User-Agent: Go-http-client/1.1
Transfer-Encoding: chunked
Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzZXJ2ZXIiOnRydWV9.i0aGGmGBBVOA17ZDoEUPyuugjUKgm18wleyB8411-SU
Content-Type: application/json
Stream-Auth-Type: jwt
X-Stream-Client: stream-go-client
Accept-Encoding: gzip

1
n
3
ull

```