### PR TITLE
changing `users` to `members`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func main() {
 	// create channel with users
 	users := []string{"id1", "id2", "id3"}
 	channel, err := client.CreateChannel("messaging", "channel-id", userID, map[string]interface{}{
-		"users": users,
+		"members": users,
 	})
 
 	// use channel methods


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
According to the [docs](https://getstream.io/chat/docs/initialize_channel/?language=js), it looks like `members` should be used instead of `users` for the channel data