### PR TITLE
Fix quotation in documentation for GetReactions

### DIFF
--- a/reaction.go
+++ b/reaction.go
@@ -82,7 +82,7 @@ type reactionsResponse struct {
 }
 
 // GetReactions returns list of the reactions for message with given ID.
-// options: Pagination params, ie {"limit":{10}, "idlte": {10}}
+// options: Pagination params, ie {"limit":{"10"}, "idlte": {"10"}}
 func (ch *Channel) GetReactions(messageID string, options map[string][]string) ([]*Reaction, error) {
 	if messageID == "" {
 		return nil, errors.New("message ID is empty")


### PR DESCRIPTION
The example provided in the documentation for GetReactions is incorrect. I've updated the docs.
Specifically the Options type is of `map[string][]string` which means the parameters have to be strings.
