### PR TITLE
Add examples for documentation

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -45,7 +45,7 @@ func ExampleClient_UpdateAppSettings_disable_auth() {
 }
 
 func ExampleClient_UpdateAppSettings_disable_permission() {
-	client, err := NewClient("XXXXXXXXXXXX", []byte("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"))
+	client, err := NewClient("XXXX", []byte("XXXX"))
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -1,6 +1,7 @@
 package stream_chat //nolint: golint
 
 import (
+	"log"
 	"testing"
 )
 
@@ -19,4 +20,46 @@ func TestClient_UpdateAppSettings(t *testing.T) {
 
 	err := c.UpdateAppSettings(settings)
 	mustNoError(t, err)
+}
+
+// See https://getstream.io/chat/docs/app_settings_auth/ for
+// more details.
+func ExampleClient_UpdateAppSettings_disable_auth() {
+	client, err := NewClient("XXXXXXXXXXXX", []byte("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"))
+	if err != nil {
+		log.Fatalf("Err: %v", err)
+	}
+
+	// disable auth checks, allows dev token usage
+	settings := NewAppSettings().SetDisableAuth(true)
+	err = client.UpdateAppSettings(settings)
+	if err != nil {
+		log.Fatalf("Err: %v", err)
+	}
+
+	// re-enable auth checks
+	err = client.UpdateAppSettings(NewAppSettings().SetDisableAuth(false))
+	if err != nil {
+		log.Fatalf("Err: %v", err)
+	}
+}
+
+func ExampleClient_UpdateAppSettings_disable_permission() {
+	client, err := NewClient("XXXXXXXXXXXX", []byte("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"))
+	if err != nil {
+		log.Fatalf("Err: %v", err)
+	}
+
+	// disable permission checkse
+	settings := NewAppSettings().SetDisablePermissions(true)
+	err = client.UpdateAppSettings(settings)
+	if err != nil {
+		log.Fatalf("Err: %v", err)
+	}
+
+	// re-enable permission checks
+	err = client.UpdateAppSettings(NewAppSettings().SetDisablePermissions(false))
+	if err != nil {
+		log.Fatalf("Err: %v", err)
+	}
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -89,16 +89,12 @@ func TestChannel_AddMembers(t *testing.T) {
 
 // See https://getstream.io/chat/docs/channel_members/ for more details.
 func ExampleChannel_AddModerators() {
-	var err error
 	channel := &Channel{}
 	newModerators := []string{"bob", "sue"}
 
-	err = channel.AddModerators("thierry", "josh")
-	err = channel.AddModerators(newModerators...)
-	err = channel.DemoteModerators(newModerators...)
-	if err != nil {
-		log.Fatalf("%v", err)
-	}
+	_ = channel.AddModerators("thierry", "josh")
+	_ = channel.AddModerators(newModerators...)
+	_ = channel.DemoteModerators(newModerators...)
 }
 
 func TestChannel_InviteMembers(t *testing.T) {
@@ -437,9 +433,18 @@ func ExampleChannel_Update() {
 		"roles":      map[string]string{"elon": "admin", "gwynne": "moderator"},
 	}
 
-	// TODO: upload this to documents website after we publish the change.
 	spacexChannel := client.Channel("team", "spacex")
 	if err := spacexChannel.Update(data, nil); err != nil {
 		log.Fatalf("Error: %v", err)
 	}
+}
+
+func (c *Client) ExampleClient_CreateChannel() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	channel, _ := client.CreateChannel("team", "stream", "tommaso", nil)
+	_, _ = channel.SendMessage(&Message{
+		User: &User{ID: "tomosso"},
+		Text: "hi there!",
+	}, "tomosso")
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -456,3 +456,52 @@ func ExampleClient_CreateChannelType() {
 
 	client.CreateChannelType(newChannelType)
 }
+
+func ExampleClient_ListChannelTypes() {
+	client := &Client{}
+	client.ListChannelTypes()
+}
+
+func ExampleClient_GetChannelType() {
+	client := &Client{}
+	client.GetChannelType("public")
+}
+
+func ExampleClient_UpdateChannelType() {
+	client := &Client{}
+
+	client.UpdateChannelType("public", map[string]interface{}{
+		"permissions": []map[string]interface{}{
+			map[string]interface{}{
+				"name":      "Allow reads for all",
+				"priority":  999,
+				"resources": []string{"ReadChannel", "CreateMessage"},
+				"role":      "*",
+				"action":    "Allow",
+			},
+			map[string]interface{}{
+				"name":      "Deny all",
+				"priority":  1,
+				"resources": []string{"*"},
+				"role":      "*",
+				"action":    "Deny",
+			},
+		},
+		"replies":  false,
+		"commands": []string{"all"},
+	})
+}
+
+func ExampleClient_UpdateChannelType_bool() {
+	client := &Client{}
+
+	client.UpdateChannelType("public", map[string]interface{}{
+		"typing_events":  false,
+		"read_events":    true,
+		"connect_events": true,
+		"search":         false,
+		"reactions":      true,
+		"replies":        false,
+		"mutes":          true,
+	})
+}

--- a/channel_test.go
+++ b/channel_test.go
@@ -428,6 +428,7 @@ func TestChannel_RejectInvite(t *testing.T) {
 }
 
 func ExampleChannel_Update() {
+	// https://getstream.io/chat/docs/channel_permissions/?language=python
 	client := &Client{}
 
 	data := map[string]interface{}{
@@ -436,6 +437,7 @@ func ExampleChannel_Update() {
 		"roles":      map[string]string{"elon": "admin", "gwynne": "moderator"},
 	}
 
+	// TODO: upload this to documents website after we publish the change.
 	spacexChannel := client.Channel("team", "spacex")
 	if err := spacexChannel.Update(data, nil); err != nil {
 		log.Fatalf("Error: %v", err)

--- a/channel_test.go
+++ b/channel_test.go
@@ -435,12 +435,9 @@ func ExampleChannel_Update() {
 		"created_by": "elon",
 		"roles":      map[string]string{"elon": "admin", "gwynne": "moderator"},
 	}
-	_, _ = client, data
 
-	// TODO: we don't seem to have a GetChannel or Channel function.
-	//spacexChannel, err := client.GetChannel("team", "spacex")
-	//	if err != nil {
-	//		log.Fatalf("Error: %v", err)
-	//	}
-	//spacexChannel.update(data)
+	spacexChannel := client.Channel("team", "spacex")
+	if err := spacexChannel.Update(data, nil); err != nil {
+		log.Fatalf("Error: %v", err)
+	}
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -5,16 +5,10 @@ import (
 	"os"
 	"path"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func channelDeleteHelper(t *testing.T, channel *Channel) {
-	time.Sleep(time.Second / 4)
-	mustNoError(t, channel.Delete(), "delete channel")
-}
 
 func TestClient_CreateChannel(t *testing.T) {
 	c := initClient(t)
@@ -74,7 +68,7 @@ func TestChannel_AddMembers(t *testing.T) {
 	ch, err := c.CreateChannel("messaging", chanID, serverUser.ID, nil)
 	mustNoError(t, err, "create channel")
 	defer func() {
-		channelDeleteHelper(t, ch)
+		_ = ch.Delete()
 	}()
 
 	assert.Empty(t, ch.Members, "members are empty")
@@ -111,7 +105,7 @@ func TestChannel_InviteMembers(t *testing.T) {
 	ch, err := c.CreateChannel("messaging", chanID, serverUser.ID, nil)
 	mustNoError(t, err, "create channel")
 	defer func() {
-		channelDeleteHelper(t, ch)
+		_ = ch.Delete()
 	}()
 
 	assert.Empty(t, ch.Members, "members are empty")
@@ -138,7 +132,7 @@ func TestChannel_Moderation(t *testing.T) {
 	ch, err := c.CreateChannel("messaging", chanID, serverUser.ID, nil)
 	mustNoError(t, err, "create channel")
 	defer func() {
-		channelDeleteHelper(t, ch)
+		_ = ch.Delete()
 	}()
 
 	assert.Empty(t, ch.Members, "members are empty")
@@ -172,7 +166,7 @@ func TestChannel_BanUser(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		channelDeleteHelper(t, ch)
+		_ = ch.Delete()
 	}()
 
 	user := randomUser()
@@ -201,7 +195,7 @@ func TestChannel_GetReplies(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		channelDeleteHelper(t, ch)
+		_ = ch.Delete()
 	}()
 
 	user := randomUser()
@@ -228,7 +222,7 @@ func TestChannel_RemoveMembers(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		channelDeleteHelper(t, ch)
+		_ = ch.Delete()
 	}()
 
 	user := randomUser()
@@ -252,7 +246,7 @@ func TestChannel_SendMessage(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		channelDeleteHelper(t, ch)
+		_ = ch.Delete()
 	}()
 
 	user := randomUser()
@@ -272,7 +266,7 @@ func TestChannel_Truncate(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		channelDeleteHelper(t, ch)
+		_ = ch.Delete()
 	}()
 
 	user := randomUser()

--- a/channel_test.go
+++ b/channel_test.go
@@ -427,81 +427,20 @@ func TestChannel_RejectInvite(t *testing.T) {
 	require.NoError(t, err, "reject invite")
 }
 
-// See https://getstream.io/chat/docs/channel_features/ for more details.
-func ExampleClient_CreateChannelType() {
+func ExampleChannel_Update() {
 	client := &Client{}
 
-	newChannelType := &ChannelType{
-		// Copy the default settings.
-		ChannelConfig: DefaultChannelConfig,
+	data := map[string]interface{}{
+		"image":      "https://path/to/image",
+		"created_by": "elon",
+		"roles":      map[string]string{"elon": "admin", "gwynne": "moderator"},
 	}
+	_, _ = client, data
 
-	newChannelType.Name = "public"
-	newChannelType.Mutes = false
-	newChannelType.Reactions = false
-	newChannelType.Permissions = append(newChannelType.Permissions,
-		&Permission{
-			Name:      "Allow reads for all",
-			Priority:  999,
-			Resources: []string{"ReadChannel", "CreateMessage"},
-			Action:    "Allow",
-		},
-		&Permission{
-			Name:      "Deny all",
-			Priority:  1,
-			Resources: []string{"*"},
-			Action:    "Deny",
-		},
-	)
-
-	client.CreateChannelType(newChannelType)
-}
-
-func ExampleClient_ListChannelTypes() {
-	client := &Client{}
-	client.ListChannelTypes()
-}
-
-func ExampleClient_GetChannelType() {
-	client := &Client{}
-	client.GetChannelType("public")
-}
-
-func ExampleClient_UpdateChannelType() {
-	client := &Client{}
-
-	client.UpdateChannelType("public", map[string]interface{}{
-		"permissions": []map[string]interface{}{
-			map[string]interface{}{
-				"name":      "Allow reads for all",
-				"priority":  999,
-				"resources": []string{"ReadChannel", "CreateMessage"},
-				"role":      "*",
-				"action":    "Allow",
-			},
-			map[string]interface{}{
-				"name":      "Deny all",
-				"priority":  1,
-				"resources": []string{"*"},
-				"role":      "*",
-				"action":    "Deny",
-			},
-		},
-		"replies":  false,
-		"commands": []string{"all"},
-	})
-}
-
-func ExampleClient_UpdateChannelType_bool() {
-	client := &Client{}
-
-	client.UpdateChannelType("public", map[string]interface{}{
-		"typing_events":  false,
-		"read_events":    true,
-		"connect_events": true,
-		"search":         false,
-		"reactions":      true,
-		"replies":        false,
-		"mutes":          true,
-	})
+	// TODO: we don't seem to have a GetChannel or Channel function.
+	//spacexChannel, err := client.GetChannel("team", "spacex")
+	//	if err != nil {
+	//		log.Fatalf("Error: %v", err)
+	//	}
+	//spacexChannel.update(data)
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -1,6 +1,7 @@
 package stream_chat // nolint: golint
 
 import (
+	"log"
 	"os"
 	"path"
 	"testing"
@@ -84,6 +85,20 @@ func TestChannel_AddMembers(t *testing.T) {
 	mustNoError(t, ch.refresh(), "refresh channel")
 
 	assert.Equal(t, user.ID, ch.Members[0].User.ID, "members contain user id")
+}
+
+// See https://getstream.io/chat/docs/channel_members/ for more details.
+func ExampleChannel_AddModerators() {
+	var err error
+	channel := &Channel{}
+	newModerators := []string{"bob", "sue"}
+
+	err = channel.AddModerators("thierry", "josh")
+	err = channel.AddModerators(newModerators...)
+	err = channel.DemoteModerators(newModerators...)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
 }
 
 func TestChannel_InviteMembers(t *testing.T) {
@@ -410,4 +425,34 @@ func TestChannel_RejectInvite(t *testing.T) {
 	require.NoError(t, err, "create channel")
 	err = ch.RejectInvite(members[0], &Message{Text: "rejected", User: &User{ID: members[0]}})
 	require.NoError(t, err, "reject invite")
+}
+
+// See https://getstream.io/chat/docs/channel_features/ for more details.
+func ExampleClient_CreateChannelType() {
+	client := &Client{}
+
+	newChannelType := &ChannelType{
+		// Copy the default settings.
+		ChannelConfig: DefaultChannelConfig,
+	}
+
+	newChannelType.Name = "public"
+	newChannelType.Mutes = false
+	newChannelType.Reactions = false
+	newChannelType.Permissions = append(newChannelType.Permissions,
+		&Permission{
+			Name:      "Allow reads for all",
+			Priority:  999,
+			Resources: []string{"ReadChannel", "CreateMessage"},
+			Action:    "Allow",
+		},
+		&Permission{
+			Name:      "Deny all",
+			Priority:  1,
+			Resources: []string{"*"},
+			Action:    "Deny",
+		},
+	)
+
+	client.CreateChannelType(newChannelType)
 }

--- a/channel_test.go
+++ b/channel_test.go
@@ -5,10 +5,16 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func channelDeleteHelper(t *testing.T, channel *Channel) {
+	time.Sleep(time.Second / 4)
+	mustNoError(t, channel.Delete(), "delete channel")
+}
 
 func TestClient_CreateChannel(t *testing.T) {
 	c := initClient(t)
@@ -68,7 +74,7 @@ func TestChannel_AddMembers(t *testing.T) {
 	ch, err := c.CreateChannel("messaging", chanID, serverUser.ID, nil)
 	mustNoError(t, err, "create channel")
 	defer func() {
-		mustNoError(t, ch.Delete(), "delete channel")
+		channelDeleteHelper(t, ch)
 	}()
 
 	assert.Empty(t, ch.Members, "members are empty")
@@ -105,7 +111,7 @@ func TestChannel_InviteMembers(t *testing.T) {
 	ch, err := c.CreateChannel("messaging", chanID, serverUser.ID, nil)
 	mustNoError(t, err, "create channel")
 	defer func() {
-		mustNoError(t, ch.Delete(), "delete channel")
+		channelDeleteHelper(t, ch)
 	}()
 
 	assert.Empty(t, ch.Members, "members are empty")
@@ -132,7 +138,7 @@ func TestChannel_Moderation(t *testing.T) {
 	ch, err := c.CreateChannel("messaging", chanID, serverUser.ID, nil)
 	mustNoError(t, err, "create channel")
 	defer func() {
-		mustNoError(t, ch.Delete(), "delete channel")
+		channelDeleteHelper(t, ch)
 	}()
 
 	assert.Empty(t, ch.Members, "members are empty")
@@ -166,7 +172,7 @@ func TestChannel_BanUser(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		mustNoError(t, ch.Delete(), "delete channel")
+		channelDeleteHelper(t, ch)
 	}()
 
 	user := randomUser()
@@ -195,7 +201,7 @@ func TestChannel_GetReplies(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		mustNoError(t, ch.Delete(), "delete channel")
+		channelDeleteHelper(t, ch)
 	}()
 
 	user := randomUser()
@@ -222,7 +228,7 @@ func TestChannel_RemoveMembers(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		mustNoError(t, ch.Delete(), "delete channel")
+		channelDeleteHelper(t, ch)
 	}()
 
 	user := randomUser()
@@ -246,7 +252,7 @@ func TestChannel_SendMessage(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		mustNoError(t, ch.Delete(), "delete channel")
+		channelDeleteHelper(t, ch)
 	}()
 
 	user := randomUser()
@@ -266,7 +272,7 @@ func TestChannel_Truncate(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		mustNoError(t, ch.Delete(), "delete channel")
+		channelDeleteHelper(t, ch)
 	}()
 
 	user := randomUser()

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -72,32 +72,32 @@ func ExampleClient_CreateChannelType() {
 		},
 	)
 
-	client.CreateChannelType(newChannelType)
+	_, _ = client.CreateChannelType(newChannelType)
 }
 
 func ExampleClient_ListChannelTypes() {
 	client := &Client{}
-	client.ListChannelTypes()
+	_, _ = client.ListChannelTypes()
 }
 
 func ExampleClient_GetChannelType() {
 	client := &Client{}
-	client.GetChannelType("public")
+	_, _ = client.GetChannelType("public")
 }
 
 func ExampleClient_UpdateChannelType() {
 	client := &Client{}
 
-	client.UpdateChannelType("public", map[string]interface{}{
+	_ = client.UpdateChannelType("public", map[string]interface{}{
 		"permissions": []map[string]interface{}{
-			map[string]interface{}{
+			{
 				"name":      "Allow reads for all",
 				"priority":  999,
 				"resources": []string{"ReadChannel", "CreateMessage"},
 				"role":      "*",
 				"action":    "Allow",
 			},
-			map[string]interface{}{
+			{
 				"name":      "Deny all",
 				"priority":  1,
 				"resources": []string{"*"},
@@ -113,7 +113,7 @@ func ExampleClient_UpdateChannelType() {
 func ExampleClient_UpdateChannelType_bool() {
 	client := &Client{}
 
-	client.UpdateChannelType("public", map[string]interface{}{
+	_ = client.UpdateChannelType("public", map[string]interface{}{
 		"typing_events":  false,
 		"read_events":    true,
 		"connect_events": true,
@@ -127,7 +127,7 @@ func ExampleClient_UpdateChannelType_bool() {
 func ExampleClient_UpdateChannelType_other() {
 	client := &Client{}
 
-	client.UpdateChannelType(
+	_ = client.UpdateChannelType(
 		"public",
 		map[string]interface{}{
 			"automod":            "disabled",
@@ -141,7 +141,7 @@ func ExampleClient_UpdateChannelType_other() {
 func ExampleClient_UpdateChannelType_permissions() {
 	client := &Client{}
 
-	client.UpdateChannelType(
+	_ = client.UpdateChannelType(
 		"public",
 		map[string]interface{}{
 			"permissions": []map[string]interface{}{
@@ -166,5 +166,5 @@ func ExampleClient_UpdateChannelType_permissions() {
 func ExampleClient_DeleteChannelType() {
 	client := &Client{}
 
-	client.DeleteChannelType("public")
+	_ = client.DeleteChannelType("public")
 }

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -2,17 +2,9 @@ package stream_chat // nolint: golint
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func channelTypeDeleteHelper(t *testing.T, client *Client, name string) {
-	// Deleting the channel sometimes fails. Adding a delay to hopefully
-	// prevent this.
-	time.Sleep(time.Second / 2)
-	mustNoError(t, client.DeleteChannelType(name), "delete channel type")
-}
 
 func prepareChannelType(t *testing.T, c *Client) *ChannelType {
 	ct := NewChannelType(randomString(10))
@@ -28,7 +20,7 @@ func TestClient_GetChannelType(t *testing.T) {
 
 	ct := prepareChannelType(t, c)
 	defer func() {
-		channelTypeDeleteHelper(t, c, ct.Name)
+		_ = c.DeleteChannelType(ct.Name)
 	}()
 
 	got, err := c.GetChannelType(ct.Name)
@@ -44,7 +36,7 @@ func TestClient_ListChannelTypes(t *testing.T) {
 
 	ct := prepareChannelType(t, c)
 	defer func() {
-		channelTypeDeleteHelper(t, c, ct.Name)
+		_ = c.DeleteChannelType(ct.Name)
 	}()
 
 	got, err := c.ListChannelTypes()

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -2,6 +2,7 @@ package stream_chat // nolint: golint
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,6 +21,9 @@ func TestClient_GetChannelType(t *testing.T) {
 
 	ct := prepareChannelType(t, c)
 	defer func() {
+		// Deleting the channel sometimes fails. Adding a delay to hopefully
+		// prevent this.
+		time.Sleep(time.Second / 2)
 		mustNoError(t, c.DeleteChannelType(ct.Name), "delete channel type")
 	}()
 

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -44,3 +44,127 @@ func TestClient_ListChannelTypes(t *testing.T) {
 
 	assert.Contains(t, got, ct.Name)
 }
+
+// See https://getstream.io/chat/docs/channel_features/ for more details.
+func ExampleClient_CreateChannelType() {
+	client := &Client{}
+
+	newChannelType := &ChannelType{
+		// Copy the default settings.
+		ChannelConfig: DefaultChannelConfig,
+	}
+
+	newChannelType.Name = "public"
+	newChannelType.Mutes = false
+	newChannelType.Reactions = false
+	newChannelType.Permissions = append(newChannelType.Permissions,
+		&Permission{
+			Name:      "Allow reads for all",
+			Priority:  999,
+			Resources: []string{"ReadChannel", "CreateMessage"},
+			Action:    "Allow",
+		},
+		&Permission{
+			Name:      "Deny all",
+			Priority:  1,
+			Resources: []string{"*"},
+			Action:    "Deny",
+		},
+	)
+
+	client.CreateChannelType(newChannelType)
+}
+
+func ExampleClient_ListChannelTypes() {
+	client := &Client{}
+	client.ListChannelTypes()
+}
+
+func ExampleClient_GetChannelType() {
+	client := &Client{}
+	client.GetChannelType("public")
+}
+
+func ExampleClient_UpdateChannelType() {
+	client := &Client{}
+
+	client.UpdateChannelType("public", map[string]interface{}{
+		"permissions": []map[string]interface{}{
+			map[string]interface{}{
+				"name":      "Allow reads for all",
+				"priority":  999,
+				"resources": []string{"ReadChannel", "CreateMessage"},
+				"role":      "*",
+				"action":    "Allow",
+			},
+			map[string]interface{}{
+				"name":      "Deny all",
+				"priority":  1,
+				"resources": []string{"*"},
+				"role":      "*",
+				"action":    "Deny",
+			},
+		},
+		"replies":  false,
+		"commands": []string{"all"},
+	})
+}
+
+func ExampleClient_UpdateChannelType_bool() {
+	client := &Client{}
+
+	client.UpdateChannelType("public", map[string]interface{}{
+		"typing_events":  false,
+		"read_events":    true,
+		"connect_events": true,
+		"search":         false,
+		"reactions":      true,
+		"replies":        false,
+		"mutes":          true,
+	})
+}
+
+func ExampleClient_UpdateChannelType_other() {
+	client := &Client{}
+
+	client.UpdateChannelType(
+		"public",
+		map[string]interface{}{
+			"automod":            "disabled",
+			"message_retention":  "7",
+			"max_message_length": 140,
+			"commands":           []interface{}{"ban", "unban"},
+		},
+	)
+}
+
+func ExampleClient_UpdateChannelType_permissions() {
+	client := &Client{}
+
+	client.UpdateChannelType(
+		"public",
+		map[string]interface{}{
+			"permissions": []map[string]interface{}{
+				{
+					"name":      "Allow reads for all",
+					"priority":  999,
+					"resources": []string{"ReadChannel", "CreateMessage"},
+					"role":      "*",
+					"action":    "Allow",
+				},
+				{
+					"name":      "Deny all",
+					"priority":  1,
+					"resources": []string{"*"},
+					"action":    "Deny",
+				},
+			},
+		},
+	)
+}
+
+func ExampleClient_DeleteChannelType() {
+	client := &Client{}
+
+	client.DeleteChannelType("public")
+}

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -7,6 +7,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func channelTypeDeleteHelper(t *testing.T, client *Client, name string) {
+	// Deleting the channel sometimes fails. Adding a delay to hopefully
+	// prevent this.
+	time.Sleep(time.Second / 2)
+	mustNoError(t, client.DeleteChannelType(name), "delete channel type")
+}
+
 func prepareChannelType(t *testing.T, c *Client) *ChannelType {
 	ct := NewChannelType(randomString(10))
 
@@ -21,10 +28,7 @@ func TestClient_GetChannelType(t *testing.T) {
 
 	ct := prepareChannelType(t, c)
 	defer func() {
-		// Deleting the channel sometimes fails. Adding a delay to hopefully
-		// prevent this.
-		time.Sleep(time.Second / 2)
-		mustNoError(t, c.DeleteChannelType(ct.Name), "delete channel type")
+		channelTypeDeleteHelper(t, c, ct.Name)
 	}()
 
 	got, err := c.GetChannelType(ct.Name)
@@ -40,7 +44,7 @@ func TestClient_ListChannelTypes(t *testing.T) {
 
 	ct := prepareChannelType(t, c)
 	defer func() {
-		mustNoError(t, c.DeleteChannelType(ct.Name), "delete channel type")
+		channelTypeDeleteHelper(t, c, ct.Name)
 	}()
 
 	got, err := c.ListChannelTypes()

--- a/client.go
+++ b/client.go
@@ -303,12 +303,13 @@ func NewClient(apiKey string, apiSecret []byte) (*Client, error) {
 	return client, nil
 }
 
-// Channel prepares a Channel object for future API calls.
+// Channel prepares a Channel object for future API calls. This does not in and
+// of itself call the API.
 func (c *Client) Channel(channelType string, channelID string) *Channel {
 	return &Channel{
 		client: c,
 
-		ID: channelID,
+		ID:   channelID,
 		Type: channelType,
 	}
 }

--- a/client.go
+++ b/client.go
@@ -302,3 +302,13 @@ func NewClient(apiKey string, apiSecret []byte) (*Client, error) {
 
 	return client, nil
 }
+
+// Channel prepares a Channel object for future API calls.
+func (c *Client) Channel(channelType string, channelID string) *Channel {
+	return &Channel{
+		client: c,
+
+		ID: channelID,
+		Type: channelType,
+	}
+}

--- a/device_test.go
+++ b/device_test.go
@@ -37,3 +37,21 @@ func deviceIDExists(dev []*Device, id string) bool {
 	}
 	return false
 }
+
+func ExampleClient_AddDevice() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	_ = client.AddDevice(&Device{
+		ID:           "2ffca4ad6599adc9b5202d15a5286d33c19547d472cd09de44219cda5ac30207",
+		UserID:       "elon",
+		PushProvider: PushProviderAPNS,
+	})
+}
+
+func ExampleClient_DeleteDevice() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	deviceID := "2ffca4ad6599adc9b5202d15a5286d33c19547d472cd09de44219cda5ac30207"
+	userID := "elon"
+	_ = client.DeleteDevice(userID, deviceID)
+}

--- a/reaction_test.go
+++ b/reaction_test.go
@@ -1,10 +1,26 @@
 package stream_chat // nolint: golint
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func ExampleChannel_SendReaction() {
+	channel := &Channel{}
+	msgID := "123"
+	userID := "bob-1"
+
+	reaction := &Reaction{
+		Type:      "love",
+		ExtraData: map[string]interface{}{"my_custom_field": 123},
+	}
+	_, err := channel.SendReaction(reaction, msgID, userID)
+	if err != nil {
+		log.Fatalf("Found Error: %v", err)
+	}
+}
 
 func TestChannel_SendReaction(t *testing.T) {
 	c := initClient(t)

--- a/user_test.go
+++ b/user_test.go
@@ -1,6 +1,7 @@
 package stream_chat // nolint: golint
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -123,4 +124,17 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 	assert.Contains(t, got, user.ID)
 	assert.Contains(t, got[user.ID].ExtraData, "test", "extra data contains", got[user.ID].ExtraData)
 	assert.Empty(t, got[user.ID].ExtraData["test"], "extra data field removed")
+}
+
+func ExampleClient_UpdateUser() {
+	client := &Client{}
+
+	_, err := client.UpdateUser(&User{
+		ID:   "tommaso",
+		Name: "Tommaso",
+		Role: "Admin",
+	})
+	if err != nil {
+		log.Fatalf("Err: %v", err)
+	}
 }

--- a/user_test.go
+++ b/user_test.go
@@ -127,7 +127,7 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 }
 
 func ExampleClient_UpdateUser() {
-	client := &Client{}
+	client, _ := NewClient("XXXX", []byte("XXXX"))
 
 	_, err := client.UpdateUser(&User{
 		ID:   "tommaso",
@@ -137,4 +137,60 @@ func ExampleClient_UpdateUser() {
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
+}
+
+func ExampleClient_ExportUser() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	user, _ := client.ExportUser("userID", nil)
+	log.Printf("%#v", user)
+}
+
+func ExampleClient_DeactivateUser() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	_ = client.DeactivateUser("userID", nil)
+}
+
+func ExampleClient_ReactivateUser() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	_ = client.ReactivateUser("userID", nil)
+}
+
+func ExampleClient_DeleteUser() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	_ = client.DeleteUser("userID", nil)
+}
+
+func ExampleClient_DeleteUser_hard() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	options := map[string][]string{
+		"mark_messages_deleted": {"true"},
+		"hard_delete":           {"true"},
+	}
+
+	_ = client.DeleteUser("userID", options)
+}
+
+func ExampleClient_BanUser() {
+	client, _ := NewClient("XXXX", []byte("XXXX"))
+
+	// ban a user for 60 minutes from all channel
+	_ = client.BanUser("eviluser", "modUser",
+		map[string]interface{}{"timeout": 60, "reason": "Banned for one hour"})
+
+	// ban a user from the livestream:fortnite channel
+	channel := client.Channel("livestream", "fortnite")
+	_ = channel.BanUser("eviluser", "modUser",
+		map[string]interface{}{"reason": "Profanity is not allowed here"})
+
+	// remove ban from channel
+	channel = client.Channel("livestream", "fortnite")
+	_ = channel.UnBanUser("eviluser", nil)
+
+	// remove global ban
+	_ = client.UnBanUser("eviluser", nil)
 }


### PR DESCRIPTION
These are mostly examples I wrote for the website proper, but I decided they would fit well in here.

There are a few small changes that fall out side of that.

1. I added a small delay in one of the tests before test cleanup. This was due to it intermittently failing causing the tests to fail.
2. I added a `(*Client).Channel` function which makes it easier to get a channel with known values. It doesn't make an API call in and of itself, just gives you an object that can be used for API calls.