### PR TITLE
Use go1.14

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goVer: [1.12, 1.13]
+        goVer: [1.13, 1.14]
     steps:
       - name: Set up Go ${{ matrix.goVer }}
         uses: actions/setup-go@v1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GetStream/stream-chat-go/v2
 
-go 1.12
+go 1.13
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible


### PR DESCRIPTION
* test with go1.14 (aligned with go versioning)
* bump min required to go1.13 (error wrapping can be used)