### PR TITLE
Attempt to add pagination functions

### DIFF
--- a/query.go
+++ b/query.go
@@ -191,7 +191,7 @@ func (c *Client) PageQueryChannels(q *QueryOption, paginationFunc ChannelPaginat
 		*newQ = *q
 	}
 
-	for i := opt.StartingOffset; ; i++ {
+	for i := (opt.StartingOffset / opt.Limit); ; i++ {
 		newQ.Limit = opt.Limit
 		newQ.Offset = opt.Limit * i
 
@@ -227,7 +227,7 @@ func (c *Client) PageQueryUsers(q *QueryOption, paginationFunc UserPaginationFun
 		*newQ = *q
 	}
 
-	for i := opt.StartingOffset; ; i++ {
+	for i := (opt.StartingOffset / opt.Limit); ; i++ {
 		newQ.Limit = opt.Limit
 		newQ.Offset = opt.Limit * i
 

--- a/query.go
+++ b/query.go
@@ -176,7 +176,11 @@ type UserPaginationFunc func([]*User) bool
 
 // PageQueryChannels allows you to paginate through a query results. It takes a
 // paginationFunc and an optional set of PaginationOptions.
-func (c *Client) PageQueryChannels(q *QueryOption, paginationFunc ChannelPaginationFunc, options ...PaginationOptions) error {
+func (c *Client) PageQueryChannels(
+	q *QueryOption,
+	paginationFunc ChannelPaginationFunc,
+	options ...PaginationOptions,
+) error {
 	if paginationFunc == nil {
 		return errors.New("must pass a pagination function")
 	}
@@ -212,7 +216,11 @@ func (c *Client) PageQueryChannels(q *QueryOption, paginationFunc ChannelPaginat
 
 // PageQueryUsers allows you to paginate through a query results. It takes a
 // paginationFunc and an optional set of PaginationOptions.
-func (c *Client) PageQueryUsers(q *QueryOption, paginationFunc UserPaginationFunc, options ...PaginationOptions) error {
+func (c *Client) PageQueryUsers(
+	q *QueryOption,
+	paginationFunc UserPaginationFunc,
+	options ...PaginationOptions,
+) error {
 	if paginationFunc == nil {
 		return errors.New("must pass a pagination function")
 	}

--- a/query.go
+++ b/query.go
@@ -12,10 +12,12 @@ import (
 	jwriter "github.com/mailru/easyjson/jwriter"
 )
 
+type Map map[string]interface{}
+
 type QueryOption struct {
 	// https://getstream.io/chat/docs/#query_syntax
-	Filter map[string]interface{} `json:"filter_conditions,omitempty"`
-	Sort   []*SortOption          `json:"sort,omitempty"`
+	Filter Map           `json:"filter_conditions,omitempty"`
+	Sort   []*SortOption `json:"sort,omitempty"`
 
 	UserID string `json:"user_id,omitempty"`
 	Limit  int    `json:"limit,omitempty"`  // pagination option: limit number of results
@@ -162,9 +164,18 @@ func getPageOptions(options []PaginationOptions) PaginationOptions {
 	return result
 }
 
+// ChannelPaginationFunc is a function that is given a list of channels. It
+// returns true if it wants another page of channels, false if you wish to
+// stop.
 type ChannelPaginationFunc func([]*Channel) bool
+
+// UserPaginationFunc is a function that is given a list of users. It
+// returns true if it wants another page of users, false if you wish to
+// stop.
 type UserPaginationFunc func([]*User) bool
 
+// PageQueryChannels allows you to paginate through a query results. It takes a
+// paginationFunc and an optional set of PaginationOptions.
 func (c *Client) PageQueryChannels(q *QueryOption, paginationFunc ChannelPaginationFunc, options ...PaginationOptions) error {
 	if paginationFunc == nil {
 		return errors.New("must pass a pagination function")
@@ -199,6 +210,8 @@ func (c *Client) PageQueryChannels(q *QueryOption, paginationFunc ChannelPaginat
 	}
 }
 
+// PageQueryUsers allows you to paginate through a query results. It takes a
+// paginationFunc and an optional set of PaginationOptions.
 func (c *Client) PageQueryUsers(q *QueryOption, paginationFunc UserPaginationFunc, options ...PaginationOptions) error {
 	if paginationFunc == nil {
 		return errors.New("must pass a pagination function")

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,7 @@
 package stream_chat // nolint: golint
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,4 +65,30 @@ func TestClient_Search(t *testing.T) {
 	mustNoError(t, err)
 
 	assert.Len(t, got, 2)
+}
+
+func ExampleClient_PageQueryChannels() {
+	client, _ := NewClient(os.Getenv("STREAM_CHAT_API_KEY"), []byte(os.Getenv("STREAM_CHAT_API_SECRET")))
+
+	chns := []*Channel{}
+
+	query := &QueryOption{
+		Filter: Map{
+			"type": "messaging",
+		},
+		Sort: []*SortOption{},
+	}
+
+	err := client.PageQueryChannels(query,
+		func(input []*Channel) bool {
+			chns = append(chns, input...)
+			return true
+		},
+		PaginationOptions{
+			StartingOffset: 60,
+			Limit:          20,
+		})
+	if err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
This is an experiment at adding paging functions for querying. It is similar to what I've seen from AWS and similar libraries. It just abstracts the looping and what not from you.

Example:
```go
	results := []*chat.Channel{}

	err = client.QueryChannelsPages(&chat.QueryOption{
		Filter: map[string]interface{}{
			"members": map[string]interface{}{"$in": []string{"555"}},
		},
	}, func(more []*chat.Channel) bool {
		results = append(results, more...)
		return true
	})

	if err != nil {
		panic(err)
	}
```

Thoughts on the idea, and style? It already is helping me with some of the scripts I'm writing for support purposes.