### PR TITLE
Improve action running and new go versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,12 +1,16 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test-build:
     name: Test & Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goVer: [1.12, 1.13]
+        goVer: [1.12, 1.13, 1.14, 1.15]
     steps:
       - name: Set up Go ${{ matrix.goVer }}
         uses: actions/setup-go@v1


### PR DESCRIPTION
Instead of running push and PR, just run PR.
Add go 1.14 and 1.15.