### PR TITLE
add GetRateLimits endpoint support

### DIFF
--- a/rate_limits.go
+++ b/rate_limits.go
@@ -34,40 +34,77 @@ type GetRateLimitsResponse struct {
 	Web        RateLimitsMap `json:"web,omitempty"`
 }
 
-// GetRateLimitsOptions configures the Client.GetRateLimits call.
-type GetRateLimitsOptions struct {
-	// ServerSide, if true, restricts the returned limits to server-side clients only.
-	ServerSide bool
-	// Android, if true, restricts the returned limits to Android clients only.
-	Android bool
-	// IOS, if true, restricts the returned limits to iOS clients only.
-	IOS bool
-	// Web, if true, restricts the returned limits to web clients only.
-	Web bool
-	// Endpoints restricts the returned limits info to the specified endpoints.
-	Endpoints []string
+type getRateLimitsParams struct {
+	serverSide bool
+	android    bool
+	iOS        bool
+	web        bool
+	endpoints  []string
 }
 
-// GetRateLimits returns the current rate limit quotas and usage. If no params are toggled, all the limits
+// GetRateLimitsOption configures the Client.GetRateLimits call.
+type GetRateLimitsOption func(p *getRateLimitsParams)
+
+// WithServerSide restricts the returned limits to server-side clients only.
+func WithServerSide() GetRateLimitsOption {
+	return func(p *getRateLimitsParams) {
+		p.serverSide = true
+	}
+}
+
+// WithAndroid restricts the returned limits to Android clients only.
+func WithAndroid() GetRateLimitsOption {
+	return func(p *getRateLimitsParams) {
+		p.android = true
+	}
+}
+
+// WithIOS restricts the returned limits to iOS clients only.
+func WithIOS() GetRateLimitsOption {
+	return func(p *getRateLimitsParams) {
+		p.iOS = true
+	}
+}
+
+// WithWeb restricts the returned limits to web clients only.
+func WithWeb() GetRateLimitsOption {
+	return func(p *getRateLimitsParams) {
+		p.web = true
+	}
+}
+
+// WithEndpoints restricts the returned limits info to the specified endpoints.
+func WithEndpoints(endpoints ...string) GetRateLimitsOption {
+	return func(p *getRateLimitsParams) {
+		p.endpoints = append(p.endpoints, endpoints...)
+	}
+}
+
+// GetRateLimits returns the current rate limit quotas and usage. If no options are passed, all the limits
 // for all platforms are returned.
-func (c *Client) GetRateLimits(options GetRateLimitsOptions) (GetRateLimitsResponse, error) {
+func (c *Client) GetRateLimits(options ...GetRateLimitsOption) (GetRateLimitsResponse, error) {
 	var resp GetRateLimitsResponse
 
 	params := url.Values{}
-	if options.ServerSide {
+
+	rlParams := getRateLimitsParams{}
+	for _, opt := range options {
+		opt(&rlParams)
+	}
+	if rlParams.serverSide {
 		params.Set("server_side", "true")
 	}
-	if options.Android {
+	if rlParams.android {
 		params.Set("android", "true")
 	}
-	if options.IOS {
+	if rlParams.iOS {
 		params.Set("ios", "true")
 	}
-	if options.Web {
+	if rlParams.web {
 		params.Set("web", "true")
 	}
-	if options.Endpoints != nil {
-		for _, e := range options.Endpoints {
+	if rlParams.endpoints != nil {
+		for _, e := range rlParams.endpoints {
 			params.Add("endpoints", e)
 		}
 	}

--- a/rate_limits.go
+++ b/rate_limits.go
@@ -1,0 +1,80 @@
+package stream_chat // nolint: golint
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// RateLimitInfo represents the quota and usage for a single endpoint.
+type RateLimitInfo struct {
+	// Limit is the maximum number of API calls for a single time window (1 minute).
+	Limit int64 `json:"limit"`
+	// Remaining is the number of API calls remaining in the current time window (1 minute).
+	Remaining int64 `json:"remaining"`
+	// Reset is the Unix timestamp of the expiration of the current rate limit time window.
+	Reset int64 `json:"reset"`
+}
+
+// RateLimitsMap holds the rate limit information, where the keys are the names of the endpoints and the values are
+// the related RateLimitInfo containing the quota, usage, and reset data.
+type RateLimitsMap map[string]RateLimitInfo
+
+// ResetTime is a simple helper to get the time.Time representation of the Reset field of the given limit window.
+func (i RateLimitInfo) ResetTime() time.Time {
+	return time.Unix(i.Reset, 0)
+}
+
+// GetRateLimitsResponse is the response of the Client.GetRateLimits call. It includes, if present, the rate
+// limits for the supported platforms, namely server-side, Android, iOS, and web.
+type GetRateLimitsResponse struct {
+	ServerSide RateLimitsMap `json:"server_side,omitempty"`
+	Android    RateLimitsMap `json:"android,omitempty"`
+	IOS        RateLimitsMap `json:"ios,omitempty"`
+	Web        RateLimitsMap `json:"web,omitempty"`
+}
+
+// GetRateLimitsOptions configures the Client.GetRateLimits call.
+type GetRateLimitsOptions struct {
+	// ServerSide, if true, restricts the returned limits to server-side clients only.
+	ServerSide bool
+	// Android, if true, restricts the returned limits to Android clients only.
+	Android bool
+	// IOS, if true, restricts the returned limits to iOS clients only.
+	IOS bool
+	// Web, if true, restricts the returned limits to web clients only.
+	Web bool
+	// Endpoints restricts the returned limits info to the specified endpoints.
+	Endpoints []string
+}
+
+// GetRateLimits returns the current rate limit quotas and usage. If no params are toggled, all the limits
+// for all platforms are returned.
+func (c *Client) GetRateLimits(options GetRateLimitsOptions) (GetRateLimitsResponse, error) {
+	var resp GetRateLimitsResponse
+
+	params := url.Values{}
+	if options.ServerSide {
+		params.Set("server_side", "true")
+	}
+	if options.Android {
+		params.Set("android", "true")
+	}
+	if options.IOS {
+		params.Set("ios", "true")
+	}
+	if options.Web {
+		params.Set("web", "true")
+	}
+	if options.Endpoints != nil {
+		for _, e := range options.Endpoints {
+			params.Add("endpoints", e)
+		}
+	}
+
+	err := c.makeRequest(http.MethodGet, "rate_limits", params, nil, &resp)
+	if err != nil {
+		return GetRateLimitsResponse{}, err
+	}
+	return resp, nil
+}

--- a/rate_limits_test.go
+++ b/rate_limits_test.go
@@ -10,7 +10,7 @@ func TestClient_GetRateLimits(t *testing.T) {
 	c := initClient(t)
 
 	t.Run("get all limits", func(t *testing.T) {
-		limits, err := c.GetRateLimits(GetRateLimitsOptions{})
+		limits, err := c.GetRateLimits()
 		require.NoError(t, err)
 		require.NotEmpty(t, limits.Android)
 		require.NotEmpty(t, limits.Web)
@@ -19,9 +19,7 @@ func TestClient_GetRateLimits(t *testing.T) {
 	})
 
 	t.Run("get only a single platform", func(t *testing.T) {
-		limits, err := c.GetRateLimits(GetRateLimitsOptions{
-			ServerSide: true,
-		})
+		limits, err := c.GetRateLimits(WithServerSide())
 		require.NoError(t, err)
 		require.Empty(t, limits.Android)
 		require.Empty(t, limits.Web)
@@ -30,14 +28,14 @@ func TestClient_GetRateLimits(t *testing.T) {
 	})
 
 	t.Run("get only a few endpoints", func(t *testing.T) {
-		limits, err := c.GetRateLimits(GetRateLimitsOptions{
-			ServerSide: true,
-			Android:    true,
-			Endpoints: []string{
+		limits, err := c.GetRateLimits(
+			WithServerSide(),
+			WithAndroid(),
+			WithEndpoints(
 				"GetRateLimits",
 				"SendMessage",
-			},
-		})
+			),
+		)
 		require.NoError(t, err)
 		require.Empty(t, limits.Web)
 		require.Empty(t, limits.IOS)

--- a/rate_limits_test.go
+++ b/rate_limits_test.go
@@ -1,0 +1,53 @@
+package stream_chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_GetRateLimits(t *testing.T) {
+	c := initClient(t)
+
+	t.Run("get all limits", func(t *testing.T) {
+		limits, err := c.GetRateLimits(GetRateLimitsOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, limits.Android)
+		require.NotEmpty(t, limits.Web)
+		require.NotEmpty(t, limits.IOS)
+		require.NotEmpty(t, limits.ServerSide)
+	})
+
+	t.Run("get only a single platform", func(t *testing.T) {
+		limits, err := c.GetRateLimits(GetRateLimitsOptions{
+			ServerSide: true,
+		})
+		require.NoError(t, err)
+		require.Empty(t, limits.Android)
+		require.Empty(t, limits.Web)
+		require.Empty(t, limits.IOS)
+		require.NotEmpty(t, limits.ServerSide)
+	})
+
+	t.Run("get only a few endpoints", func(t *testing.T) {
+		limits, err := c.GetRateLimits(GetRateLimitsOptions{
+			ServerSide: true,
+			Android:    true,
+			Endpoints: []string{
+				"GetRateLimits",
+				"SendMessage",
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, limits.Web)
+		require.Empty(t, limits.IOS)
+
+		require.NotEmpty(t, limits.Android)
+		require.Len(t, limits.Android, 2)
+		require.Equal(t, limits.Android["GetRateLimits"].Limit, limits.Android["GetRateLimits"].Remaining)
+
+		require.NotEmpty(t, limits.ServerSide)
+		require.Len(t, limits.ServerSide, 2)
+		require.Greater(t, limits.ServerSide["GetRateLimits"].Limit, limits.ServerSide["GetRateLimits"].Remaining)
+	})
+}

--- a/rate_limits_test.go
+++ b/rate_limits_test.go
@@ -1,4 +1,4 @@
-package stream_chat
+package stream_chat // nolint: golint
 
 import (
 	"testing"


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

This PR introduces support for the `GetRateLimits` endpoint, which returns the current rate limits quotas and usage.

The params are thought so that if they are empty/zero they won't be included in the call and the whole list of limits will be returned.
