### PR TITLE
[CHAT-1650] Add revoke token methods and iat claim in createtoken

### DIFF
--- a/app.go
+++ b/app.go
@@ -82,17 +82,18 @@ type Policy struct {
 }
 
 type AppConfig struct {
-	Name                 string                    `json:"name"`
-	OrganizationName     string                    `json:"organization"`
-	WebhookURL           string                    `json:"webhook_url"`
-	SuspendedExplanation string                    `json:"suspended_explanation"`
-	PushNotifications    PushNotificationFields    `json:"push_notifications"`
-	ConfigNameMap        map[string]*ChannelConfig `json:"channel_configs"`
-	Policies             map[string][]Policy       `json:"policies"`
-	Suspended            bool                      `json:"suspended"`
-	DisableAuth          bool                      `json:"disable_auth_checks"`
-	DisablePermissions   bool                      `json:"disable_permissions_checks"`
-	MultiTenantEnabled   bool                      `json:"multi_tenant_enabled"`
+	Name                     string                    `json:"name"`
+	OrganizationName         string                    `json:"organization"`
+	WebhookURL               string                    `json:"webhook_url"`
+	SuspendedExplanation     string                    `json:"suspended_explanation"`
+	PushNotifications        PushNotificationFields    `json:"push_notifications"`
+	ConfigNameMap            map[string]*ChannelConfig `json:"channel_configs"`
+	Policies                 map[string][]Policy       `json:"policies"`
+	Suspended                bool                      `json:"suspended"`
+	DisableAuth              bool                      `json:"disable_auth_checks"`
+	DisablePermissions       bool                      `json:"disable_permissions_checks"`
+	MultiTenantEnabled       bool                      `json:"multi_tenant_enabled"`
+	RevokeTokensIssuedBefore *time.Time                `json:"revoke_tokens_issued_before"`
 }
 
 type appResponse struct {
@@ -117,4 +118,16 @@ func (c *Client) GetAppConfig() (*AppConfig, error) {
 //  err := client.UpdateAppSettings(settings)
 func (c *Client) UpdateAppSettings(settings *AppSettings) error {
 	return c.makeRequest(http.MethodPatch, "app", nil, settings, nil)
+}
+
+// RevokeTokens revokes all tokens for an application issued before given time.
+func (c *Client) RevokeTokens(before *time.Time) error {
+	setting := make(map[string]interface{})
+	if before == nil {
+		setting["revoke_tokens_issued_before"] = nil
+	} else {
+		setting["revoke_tokens_issued_before"] = before.Format(time.RFC3339)
+	}
+
+	return c.makeRequest(http.MethodPatch, "app", nil, setting, nil)
 }

--- a/client.go
+++ b/client.go
@@ -126,7 +126,7 @@ func (c *Client) makeRequest(method, path string, params url.Values, data, resul
 
 // CreateToken creates a new token for user with optional expire time.
 // Zero time is assumed to be no expire.
-func (c *Client) CreateToken(userID string, expire time.Time) (string, error) {
+func (c *Client) CreateToken(userID string, expire time.Time, issuedAt *time.Time) (string, error) {
 	if userID == "" {
 		return "", errors.New("user ID is empty")
 	}
@@ -136,6 +136,9 @@ func (c *Client) CreateToken(userID string, expire time.Time) (string, error) {
 	}
 	if !expire.IsZero() {
 		claims["exp"] = expire.Unix()
+	}
+	if issuedAt != nil {
+		claims["iat"] = issuedAt.Unix()
 	}
 
 	return c.createToken(claims)

--- a/client_test.go
+++ b/client_test.go
@@ -77,7 +77,7 @@ func TestClient_CreateToken(t *testing.T) {
 			c, err := NewClient("key", "secret")
 			require.NoError(t, err)
 
-			got, err := c.CreateToken(tt.args.userID, tt.args.expire)
+			got, err := c.CreateToken(tt.args.userID, tt.args.expire, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createToken() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/user.go
+++ b/user.go
@@ -347,3 +347,38 @@ func (c *Client) PartialUpdateUsers(updates []PartialUserUpdate) (map[string]*Us
 
 	return resp.Users, err
 }
+
+// RevokeUserToken revoke token for a user issued before given time.
+func (c *Client) RevokeUserToken(userID string, before *time.Time) error {
+	userUpdate := PartialUserUpdate{
+		ID:  userID,
+		Set: make(map[string]interface{}),
+	}
+	if before == nil {
+		userUpdate.Set["revoke_tokens_issued_before"] = nil
+	} else {
+		userUpdate.Set["revoke_tokens_issued_before"] = before.Format(time.RFC3339)
+	}
+	_, err := c.PartialUpdateUser(userUpdate)
+	return err
+}
+
+// RevokeUsersTokens revoke tokens for users issued before given time.
+func (c *Client) RevokeUsersTokens(userIDs []string, before *time.Time) error {
+	userUpdates := make([]PartialUserUpdate, 0)
+	for _, userID := range userIDs {
+		userUpdate := PartialUserUpdate{
+			ID:  userID,
+			Set: make(map[string]interface{}),
+		}
+		if before == nil {
+			userUpdate.Set["revoke_tokens_issued_before"] = nil
+		} else {
+			userUpdate.Set["revoke_tokens_issued_before"] = before.Format(time.RFC3339)
+		}
+		userUpdates = append(userUpdates, userUpdate)
+	}
+
+	_, err := c.PartialUpdateUsers(userUpdates)
+	return err
+}

--- a/user.go
+++ b/user.go
@@ -46,9 +46,10 @@ type User struct {
 	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
 	LastActive *time.Time `json:"last_active,omitempty"`
 
-	Mutes        []*Mute                `json:"mutes,omitempty"`
-	ChannelMutes []*ChannelMute         `json:"channel_mutes,omitempty"`
-	ExtraData    map[string]interface{} `json:"-"`
+	Mutes                    []*Mute                `json:"mutes,omitempty"`
+	ChannelMutes             []*ChannelMute         `json:"channel_mutes,omitempty"`
+	ExtraData                map[string]interface{} `json:"-"`
+	RevokeTokensIssuedBefore *time.Time             `json:"revoke_tokens_issued_before,omitempty"`
 }
 
 type userForJSON User
@@ -350,17 +351,7 @@ func (c *Client) PartialUpdateUsers(updates []PartialUserUpdate) (map[string]*Us
 
 // RevokeUserToken revoke token for a user issued before given time.
 func (c *Client) RevokeUserToken(userID string, before *time.Time) error {
-	userUpdate := PartialUserUpdate{
-		ID:  userID,
-		Set: make(map[string]interface{}),
-	}
-	if before == nil {
-		userUpdate.Set["revoke_tokens_issued_before"] = nil
-	} else {
-		userUpdate.Set["revoke_tokens_issued_before"] = before.Format(time.RFC3339)
-	}
-	_, err := c.PartialUpdateUser(userUpdate)
-	return err
+	return c.RevokeUsersTokens([]string{userID}, before)
 }
 
 // RevokeUsersTokens revoke tokens for users issued before given time.


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Adds token revocation helpers methods

- `RevokeTokens()`
- `RevokeUserToken()`
- `RevokeUsersTokens()`

also adds a `iat` param in `CreateToken()` to be set while token generation.
