### PR TITLE
Proxy command list to createTypeRequest when creating channel type

### DIFF
--- a/channel_type.go
+++ b/channel_type.go
@@ -57,6 +57,10 @@ type ChannelType struct {
 func (ct *ChannelType) toRequest() channelTypeRequest {
 	req := channelTypeRequest{ChannelType: ct}
 
+	for _, cmd := range ct.Commands {
+		req.Commands = append(req.Commands, cmd.Name)
+	}
+
 	if len(req.Commands) == 0 {
 		req.Commands = []string{"all"}
 	}


### PR DESCRIPTION
Currently commands that set to the `ChannelType` are not proxied to the `channelTypeRequest` when creating a channel type. This PR fixes this