### PR TITLE
Add base response with rate limit info

### DIFF
--- a/app.go
+++ b/app.go
@@ -101,28 +101,31 @@ type AppConfig struct {
 	AsyncURLEnrichEnabled    bool                      `json:"async_url_enrich_enabled"`
 }
 
-type appResponse struct {
+type AppResponse struct {
 	App *AppConfig `json:"app"`
+	Response
 }
 
 // GetAppConfig returns app settings.
-func (c *Client) GetAppConfig(ctx context.Context) (*AppConfig, error) {
-	var resp appResponse
+func (c *Client) GetAppConfig(ctx context.Context) (*AppResponse, error) {
+	var resp AppResponse
 
 	err := c.makeRequest(ctx, http.MethodGet, "app", nil, nil, &resp)
-	return resp.App, err
+	return &resp, err
 }
 
 // UpdateAppSettings makes request to update app settings
 // Example of usage:
 //  settings := NewAppSettings().SetDisableAuth(true)
 //  err := client.UpdateAppSettings(settings)
-func (c *Client) UpdateAppSettings(ctx context.Context, settings *AppSettings) error {
-	return c.makeRequest(ctx, http.MethodPatch, "app", nil, settings, nil)
+func (c *Client) UpdateAppSettings(ctx context.Context, settings *AppSettings) (*Response, error) {
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPatch, "app", nil, settings, &resp)
+	return &resp, err
 }
 
 // RevokeTokens revokes all tokens for an application issued before given time.
-func (c *Client) RevokeTokens(ctx context.Context, before *time.Time) error {
+func (c *Client) RevokeTokens(ctx context.Context, before *time.Time) (*Response, error) {
 	setting := make(map[string]interface{})
 	if before == nil {
 		setting["revoke_tokens_issued_before"] = nil
@@ -130,5 +133,7 @@ func (c *Client) RevokeTokens(ctx context.Context, before *time.Time) error {
 		setting["revoke_tokens_issued_before"] = before.Format(time.RFC3339)
 	}
 
-	return c.makeRequest(ctx, http.MethodPatch, "app", nil, setting, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPatch, "app", nil, setting, &resp)
+	return &resp, err
 }

--- a/app_test.go
+++ b/app_test.go
@@ -21,7 +21,7 @@ func TestClient_UpdateAppSettings(t *testing.T) {
 		SetDisableAuth(true).
 		SetDisablePermissions(true)
 
-	err := c.UpdateAppSettings(context.Background(), settings)
+	_, err := c.UpdateAppSettings(context.Background(), settings)
 	require.NoError(t, err)
 }
 
@@ -35,13 +35,13 @@ func ExampleClient_UpdateAppSettings_disable_auth() {
 
 	// disable auth checks, allows dev token usage
 	settings := NewAppSettings().SetDisableAuth(true)
-	err = client.UpdateAppSettings(context.Background(), settings)
+	_, err = client.UpdateAppSettings(context.Background(), settings)
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
 
 	// re-enable auth checks
-	err = client.UpdateAppSettings(context.Background(), NewAppSettings().SetDisableAuth(false))
+	_, err = client.UpdateAppSettings(context.Background(), NewAppSettings().SetDisableAuth(false))
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
@@ -55,13 +55,13 @@ func ExampleClient_UpdateAppSettings_disable_permission() {
 
 	// disable permission checkse
 	settings := NewAppSettings().SetDisablePermissions(true)
-	err = client.UpdateAppSettings(context.Background(), settings)
+	_, err = client.UpdateAppSettings(context.Background(), settings)
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
 
 	// re-enable permission checks
-	err = client.UpdateAppSettings(context.Background(), NewAppSettings().SetDisablePermissions(false))
+	_, err = client.UpdateAppSettings(context.Background(), NewAppSettings().SetDisablePermissions(false))
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}

--- a/async_tasks.go
+++ b/async_tasks.go
@@ -20,38 +20,40 @@ const (
 	TaskStatusFailed    TaskStatus = "failed"
 )
 
-type Task struct {
+type TaskResponse struct {
 	TaskID    string     `json:"task_id"`
 	Status    TaskStatus `json:"status"`
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
 
 	Result map[string]interface{} `json:"result,omitempty"`
+	Response
 }
 
 // GetTask returns the status of a task that has been ran asynchronously.
-func (c *Client) GetTask(ctx context.Context, id string) (*Task, error) {
+func (c *Client) GetTask(ctx context.Context, id string) (*TaskResponse, error) {
 	if id == "" {
 		return nil, fmt.Errorf("id should not be empty")
 	}
 
 	p := path.Join("tasks", url.PathEscape(id))
 
-	var task Task
+	var task TaskResponse
 	err := c.makeRequest(ctx, http.MethodGet, p, nil, nil, &task)
 	return &task, err
 }
 
 type AsyncTaskResponse struct {
 	TaskID string `json:"task_id"`
+	Response
 }
 
 // DeleteChannels deletes channels asynchronously.
 // Channels and messages will be hard deleted if hardDelete is true.
-// It returns a task ID, the status of the task can be check with client.GetTask method.
-func (c *Client) DeleteChannels(ctx context.Context, cids []string, hardDelete bool) (string, error) {
+// It returns an AsyncTaskResponse object which contains the task ID, the status of the task can be check with client.GetTask method.
+func (c *Client) DeleteChannels(ctx context.Context, cids []string, hardDelete bool) (*AsyncTaskResponse, error) {
 	if len(cids) == 0 {
-		return "", fmt.Errorf("cids parameter should not be empty")
+		return nil, fmt.Errorf("cids parameter should not be empty")
 	}
 
 	data := struct {
@@ -64,7 +66,7 @@ func (c *Client) DeleteChannels(ctx context.Context, cids []string, hardDelete b
 
 	var resp AsyncTaskResponse
 	err := c.makeRequest(ctx, http.MethodPost, "channels/delete", nil, data, &resp)
-	return resp.TaskID, err
+	return &resp, err
 }
 
 type DeleteType string
@@ -86,10 +88,10 @@ type DeleteUserOptions struct {
 // Conversations (1to1 channels) will be deleted if either "hard" or "soft"
 // Messages will be deleted if either "hard" or "soft"
 // NewChannelOwnerID any channels owned by the hard-deleted user will be transferred to this user ID
-// It returns a task ID, the status of the task can be check with client.GetTask method.
-func (c *Client) DeleteUsers(ctx context.Context, userIDs []string, options DeleteUserOptions) (string, error) {
+// It returns an AsyncTaskResponse object which contains the task ID, the status of the task can be check with client.GetTask method.
+func (c *Client) DeleteUsers(ctx context.Context, userIDs []string, options DeleteUserOptions) (*AsyncTaskResponse, error) {
 	if len(userIDs) == 0 {
-		return "", fmt.Errorf("userIDs parameter should not be empty")
+		return nil, fmt.Errorf("userIDs parameter should not be empty")
 	}
 
 	data := struct {
@@ -102,7 +104,7 @@ func (c *Client) DeleteUsers(ctx context.Context, userIDs []string, options Dele
 
 	var resp AsyncTaskResponse
 	err := c.makeRequest(ctx, http.MethodPost, "users/delete", nil, data, &resp)
-	return resp.TaskID, err
+	return &resp, err
 }
 
 type ExportableChannel struct {
@@ -112,16 +114,16 @@ type ExportableChannel struct {
 	MessagesUntil *time.Time `json:"messages_until,omitempty"`
 }
 
-// ExportChannels requests an asynchronous export of the provided channels and returns
-// the ID of task.
-func (c *Client) ExportChannels(ctx context.Context, channels []*ExportableChannel, clearDeletedMessageText, includeTruncatedMessages *bool) (string, error) {
+// ExportChannels requests an asynchronous export of the provided channels.
+// It returns an AsyncTaskResponse object which contains the task ID, the status of the task can be check with client.GetTask method.
+func (c *Client) ExportChannels(ctx context.Context, channels []*ExportableChannel, clearDeletedMessageText, includeTruncatedMessages *bool) (*AsyncTaskResponse, error) {
 	if len(channels) == 0 {
-		return "", errors.New("number of channels must be at least one")
+		return nil, errors.New("number of channels must be at least one")
 	}
 
 	err := verifyExportableChannels(channels)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	req := struct {
@@ -136,7 +138,7 @@ func (c *Client) ExportChannels(ctx context.Context, channels []*ExportableChann
 
 	var resp AsyncTaskResponse
 	err = c.makeRequest(ctx, http.MethodPost, "export_channels", nil, req, &resp)
-	return resp.TaskID, err
+	return &resp, err
 }
 
 func verifyExportableChannels(channels []*ExportableChannel) error {
@@ -149,15 +151,14 @@ func verifyExportableChannels(channels []*ExportableChannel) error {
 }
 
 // GetExportChannelsTask returns current state of the export task.
-func (c *Client) GetExportChannelsTask(ctx context.Context, taskID string) (*Task, error) {
-	task := &Task{}
-
+func (c *Client) GetExportChannelsTask(ctx context.Context, taskID string) (*TaskResponse, error) {
 	if taskID == "" {
-		return task, errors.New("task ID must be not empty")
+		return nil, errors.New("task ID must be not empty")
 	}
 
 	p := path.Join("export_channels", url.PathEscape(taskID))
 
-	err := c.makeRequest(ctx, http.MethodGet, p, nil, nil, task)
-	return task, err
+	var task TaskResponse
+	err := c.makeRequest(ctx, http.MethodGet, p, nil, nil, &task)
+	return &task, err
 }

--- a/async_tasks_test.go
+++ b/async_tasks_test.go
@@ -97,7 +97,7 @@ func TestClient_ExportChannels(t *testing.T) {
 		}
 
 		for _, u := range chMembers {
-			_ = c.DeleteUser(context.Background(), u.UserID, options)
+			_, _ = c.DeleteUser(context.Background(), u.UserID, options)
 		}
 	}()
 

--- a/async_tasks_test.go
+++ b/async_tasks_test.go
@@ -22,17 +22,17 @@ func TestClient_DeleteChannels(t *testing.T) {
 	_, err = c.DeleteChannels(context.Background(), []string{}, true)
 	require.Error(t, err)
 
-	taskID, err := c.DeleteChannels(context.Background(), []string{ch.CID}, true)
+	resp1, err := c.DeleteChannels(context.Background(), []string{ch.CID}, true)
 	require.NoError(t, err)
-	require.NotEmpty(t, taskID)
+	require.NotEmpty(t, resp1.TaskID)
 
 	for i := 0; i < 10; i++ {
-		resp, err := c.GetTask(context.Background(), taskID)
+		resp2, err := c.GetTask(context.Background(), resp1.TaskID)
 		require.NoError(t, err)
-		require.Equal(t, taskID, resp.TaskID)
+		require.Equal(t, resp1.TaskID, resp2.TaskID)
 
-		if resp.Status == TaskStatusCompleted {
-			require.Equal(t, resp.Result[ch.CID], map[string]interface{}{"status": "ok"})
+		if resp2.Status == TaskStatusCompleted {
+			require.Equal(t, resp2.Result[ch.CID], map[string]interface{}{"status": "ok"})
 			return
 		}
 
@@ -58,20 +58,20 @@ func TestClient_DeleteUsers(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	taskID, err := c.DeleteUsers(context.Background(), []string{user.ID}, DeleteUserOptions{
+	resp1, err := c.DeleteUsers(context.Background(), []string{user.ID}, DeleteUserOptions{
 		User:     SoftDelete,
 		Messages: HardDelete,
 	})
 	require.NoError(t, err)
-	require.NotEmpty(t, taskID)
+	require.NotEmpty(t, resp1.TaskID)
 
 	for i := 0; i < 10; i++ {
-		resp, err := c.GetTask(context.Background(), taskID)
+		resp2, err := c.GetTask(context.Background(), resp1.TaskID)
 		require.NoError(t, err)
-		require.Equal(t, taskID, resp.TaskID)
+		require.Equal(t, resp1.TaskID, resp2.TaskID)
 
-		if resp.Status == TaskStatusCompleted {
-			require.Equal(t, resp.Result[user.ID], map[string]interface{}{"status": "ok"})
+		if resp2.Status == TaskStatusCompleted {
+			require.Equal(t, resp2.Result[user.ID], map[string]interface{}{"status": "ok"})
 			return
 		}
 
@@ -120,14 +120,14 @@ func TestClient_ExportChannels(t *testing.T) {
 			{Type: ch2.Type, ID: ch2.ID},
 		}
 
-		taskID, err := c.ExportChannels(context.Background(), expChannels, nil, nil)
+		resp1, err := c.ExportChannels(context.Background(), expChannels, nil, nil)
 		require.NoError(t, err)
-		require.NotEmpty(t, taskID)
+		require.NotEmpty(t, resp1.TaskID)
 
 		for i := 0; i < 10; i++ {
-			task, err := c.GetExportChannelsTask(context.Background(), taskID)
+			task, err := c.GetExportChannelsTask(context.Background(), resp1.TaskID)
 			require.NoError(t, err)
-			require.Equal(t, taskID, task.TaskID)
+			require.Equal(t, resp1.TaskID, task.TaskID)
 			require.NotEmpty(t, task.Status)
 
 			if task.Status == TaskStatusCompleted {

--- a/channel.go
+++ b/channel.go
@@ -97,6 +97,8 @@ type queryResponse struct {
 	Messages []*Message       `json:"messages,omitempty"`
 	Members  []*ChannelMember `json:"members,omitempty"`
 	Read     []*ChannelRead   `json:"read,omitempty"`
+
+	Response
 }
 
 func (q queryResponse) updateChannel(ch *Channel) {
@@ -118,12 +120,8 @@ func (q queryResponse) updateChannel(ch *Channel) {
 	}
 }
 
-type ImportChannelMessagesResponse struct {
-	Messages []Message `json:"messages"`
-}
-
 // query makes request to channel api and updates channel internal state.
-func (ch *Channel) query(ctx context.Context, options, data map[string]interface{}) (err error) {
+func (ch *Channel) query(ctx context.Context, options, data map[string]interface{}) (*Response, error) {
 	payload := map[string]interface{}{
 		"state": true,
 	}
@@ -142,20 +140,20 @@ func (ch *Channel) query(ctx context.Context, options, data map[string]interface
 
 	var resp queryResponse
 
-	err = ch.client.makeRequest(ctx, http.MethodPost, p, nil, payload, &resp)
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, payload, &resp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	resp.updateChannel(ch)
-	return nil
+	return &resp.Response, nil
 }
 
 // Update edits the channel's custom properties.
 //
 // options: the object to update the custom properties of this channel with
 // message: optional update message
-func (ch *Channel) Update(ctx context.Context, options map[string]interface{}, message *Message) error {
+func (ch *Channel) Update(ctx context.Context, options map[string]interface{}, message *Message) (*Response, error) {
 	payload := map[string]interface{}{
 		"data": options,
 	}
@@ -165,20 +163,28 @@ func (ch *Channel) Update(ctx context.Context, options map[string]interface{}, m
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, payload, nil)
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, payload, &resp)
+	return &resp, err
 }
 
 //  PartialUpdate set and unset specific fields when it is necessary to retain additional custom data fields on the object. AKA a patch style update.
 // options: the object to update the custom properties of the channel
-func (ch *Channel) PartialUpdate(ctx context.Context, update PartialUpdate) error {
+func (ch *Channel) PartialUpdate(ctx context.Context, update PartialUpdate) (*Response, error) {
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodPatch, p, nil, update, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPatch, p, nil, update, nil)
+	return &resp, err
 }
 
 // Delete removes the channel. Messages are permanently removed.
-func (ch *Channel) Delete(ctx context.Context) error {
+func (ch *Channel) Delete(ctx context.Context) (*Response, error) {
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodDelete, p, nil, nil, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodDelete, p, nil, nil, &resp)
+	return &resp, err
 }
 
 type truncateOptions struct {
@@ -217,7 +223,7 @@ func TruncateWithTruncatedAt(truncatedAt *time.Time) func(*truncateOptions) {
 // Truncate removes all messages from the channel.
 // You can pass in options such as hard_delete, skip_push
 // or a custom message.
-func (ch *Channel) Truncate(ctx context.Context, options ...TruncateOption) error {
+func (ch *Channel) Truncate(ctx context.Context, options ...TruncateOption) (*Response, error) {
 	option := &truncateOptions{}
 
 	for _, fn := range options {
@@ -225,15 +231,18 @@ func (ch *Channel) Truncate(ctx context.Context, options ...TruncateOption) erro
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "truncate")
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, option, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, option, &resp)
+	return &resp, err
 }
 
 // AddMembers adds members with given user IDs to the channel.
 // You can set a message for channel object notifications.
 // If you want to hide history of the channel for new members, you can pass "hide_history": true to options parameter.
-func (ch *Channel) AddMembers(ctx context.Context, userIDs []string, message *Message, options map[string]interface{}) error {
+func (ch *Channel) AddMembers(ctx context.Context, userIDs []string, message *Message, options map[string]interface{}) (*Response, error) {
 	if len(userIDs) == 0 {
-		return errors.New("user IDs are empty")
+		return nil, errors.New("user IDs are empty")
 	}
 
 	if options == nil {
@@ -247,13 +256,16 @@ func (ch *Channel) AddMembers(ctx context.Context, userIDs []string, message *Me
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, options, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, options, &resp)
+	return &resp, err
 }
 
 // RemoveMembers deletes members with given IDs from the channel.
-func (ch *Channel) RemoveMembers(ctx context.Context, userIDs []string, message *Message) error {
+func (ch *Channel) RemoveMembers(ctx context.Context, userIDs []string, message *Message) (*Response, error) {
 	if len(userIDs) == 0 {
-		return errors.New("user IDs are empty")
+		return nil, errors.New("user IDs are empty")
 	}
 
 	data := map[string]interface{}{
@@ -269,11 +281,11 @@ func (ch *Channel) RemoveMembers(ctx context.Context, userIDs []string, message 
 
 	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	resp.updateChannel(ch)
-	return nil
+	return &resp.Response, nil
 }
 
 type RoleAssignment struct {
@@ -285,9 +297,9 @@ type RoleAssignment struct {
 }
 
 // AssignRoles assigns roles to members with given IDs.
-func (ch *Channel) AssignRole(ctx context.Context, assignments []*RoleAssignment, msg *Message) error {
+func (ch *Channel) AssignRole(ctx context.Context, assignments []*RoleAssignment, msg *Message) (*Response, error) {
 	if len(assignments) == 0 {
-		return errors.New("assignments are empty")
+		return nil, errors.New("assignments are empty")
 	}
 
 	data := map[string]interface{}{"assign_roles": assignments}
@@ -297,15 +309,19 @@ func (ch *Channel) AssignRole(ctx context.Context, assignments []*RoleAssignment
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
 
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, nil)
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
+	return &resp, err
 }
 
-type queryMembersResponse struct {
+type QueryMembersResponse struct {
 	Members []*ChannelMember `json:"members"`
+
+	Response
 }
 
 // QueryMembers queries members of a channel.
-func (ch *Channel) QueryMembers(ctx context.Context, q *QueryOption, sorters ...*SortOption) ([]*ChannelMember, error) {
+func (ch *Channel) QueryMembers(ctx context.Context, q *QueryOption, sorters ...*SortOption) (*QueryMembersResponse, error) {
 	qp := map[string]interface{}{
 		"id":                ch.ID,
 		"type":              ch.Type,
@@ -335,25 +351,25 @@ func (ch *Channel) QueryMembers(ctx context.Context, q *QueryOption, sorters ...
 	values := url.Values{}
 	values.Set("payload", string(data))
 
-	var resp queryMembersResponse
+	var resp QueryMembersResponse
 	err = ch.client.makeRequest(ctx, http.MethodGet, "members", values, nil, &resp)
-	return resp.Members, err
+	return &resp, err
 }
 
 // AddModerators adds moderators with given IDs to the channel.
-func (ch *Channel) AddModerators(ctx context.Context, userIDs ...string) error {
+func (ch *Channel) AddModerators(ctx context.Context, userIDs ...string) (*Response, error) {
 	return ch.addModerators(ctx, userIDs, nil)
 }
 
 // AddModerators adds moderators with given IDs to the channel and produce system message.
-func (ch *Channel) AddModeratorsWithMessage(ctx context.Context, userIDs []string, msg *Message) error {
+func (ch *Channel) AddModeratorsWithMessage(ctx context.Context, userIDs []string, msg *Message) (*Response, error) {
 	return ch.addModerators(ctx, userIDs, msg)
 }
 
 // AddModerators adds moderators with given IDs to the channel.
-func (ch *Channel) addModerators(ctx context.Context, userIDs []string, msg *Message) error {
+func (ch *Channel) addModerators(ctx context.Context, userIDs []string, msg *Message) (*Response, error) {
 	if len(userIDs) == 0 {
-		return errors.New("user IDs are empty")
+		return nil, errors.New("user IDs are empty")
 	}
 
 	data := map[string]interface{}{
@@ -365,23 +381,26 @@ func (ch *Channel) addModerators(ctx context.Context, userIDs []string, msg *Mes
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
+	return &resp, err
 }
 
 // InviteMembers invites users with given IDs to the channel.
-func (ch *Channel) InviteMembers(ctx context.Context, userIDs ...string) error {
+func (ch *Channel) InviteMembers(ctx context.Context, userIDs ...string) (*Response, error) {
 	return ch.inviteMembers(ctx, userIDs, nil)
 }
 
 // InviteMembers invites users with given IDs to the channel and produce system message.
-func (ch *Channel) InviteMembersWithMessage(ctx context.Context, userIDs []string, msg *Message) error {
+func (ch *Channel) InviteMembersWithMessage(ctx context.Context, userIDs []string, msg *Message) (*Response, error) {
 	return ch.inviteMembers(ctx, userIDs, msg)
 }
 
 // InviteMembers invites users with given IDs to the channel.
-func (ch *Channel) inviteMembers(ctx context.Context, userIDs []string, msg *Message) error {
+func (ch *Channel) inviteMembers(ctx context.Context, userIDs []string, msg *Message) (*Response, error) {
 	if len(userIDs) == 0 {
-		return errors.New("user IDs are empty")
+		return nil, errors.New("user IDs are empty")
 	}
 
 	data := map[string]interface{}{
@@ -393,23 +412,26 @@ func (ch *Channel) inviteMembers(ctx context.Context, userIDs []string, msg *Mes
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
+	return &resp, err
 }
 
 // DemoteModerators moderators with given IDs from the channel.
-func (ch *Channel) DemoteModerators(ctx context.Context, userIDs ...string) error {
+func (ch *Channel) DemoteModerators(ctx context.Context, userIDs ...string) (*Response, error) {
 	return ch.demoteModerators(ctx, userIDs, nil)
 }
 
 // DemoteModerators moderators with given IDs from the channel and produce system message.
-func (ch *Channel) DemoteModeratorsWithMessage(ctx context.Context, userIDs []string, msg *Message) error {
+func (ch *Channel) DemoteModeratorsWithMessage(ctx context.Context, userIDs []string, msg *Message) (*Response, error) {
 	return ch.demoteModerators(ctx, userIDs, msg)
 }
 
 // DemoteModerators moderators with given IDs from the channel.
-func (ch *Channel) demoteModerators(ctx context.Context, userIDs []string, msg *Message) error {
+func (ch *Channel) demoteModerators(ctx context.Context, userIDs []string, msg *Message) (*Response, error) {
 	if len(userIDs) == 0 {
-		return errors.New("user IDs are empty")
+		return nil, errors.New("user IDs are empty")
 	}
 
 	data := map[string]interface{}{
@@ -421,16 +443,19 @@ func (ch *Channel) demoteModerators(ctx context.Context, userIDs []string, msg *
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
+	return &resp, err
 }
 
 // MarkRead send the mark read event for user with given ID,
 // only works if the `read_events` setting is enabled.
 // options: additional data, ie {"messageID": last_messageID}
-func (ch *Channel) MarkRead(ctx context.Context, userID string, options map[string]interface{}) error {
+func (ch *Channel) MarkRead(ctx context.Context, userID string, options map[string]interface{}) (*Response, error) {
 	switch {
 	case userID == "":
-		return errors.New("user ID must be not empty")
+		return nil, errors.New("user ID must be not empty")
 	case options == nil:
 		options = map[string]interface{}{}
 	}
@@ -438,18 +463,21 @@ func (ch *Channel) MarkRead(ctx context.Context, userID string, options map[stri
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "read")
 
 	options["user"] = map[string]interface{}{"id": userID}
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, options, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, options, &resp)
+	return &resp, err
 }
 
 // BanUser bans target user ID from this channel
 // userID: user who bans target.
 // options: additional ban options, ie {"timeout": 3600, "reason": "offensive language is not allowed here"}.
-func (ch *Channel) BanUser(ctx context.Context, targetID, userID string, options map[string]interface{}) error {
+func (ch *Channel) BanUser(ctx context.Context, targetID, userID string, options map[string]interface{}) (*Response, error) {
 	switch {
 	case targetID == "":
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	case userID == "":
-		return errors.New("user ID is empty")
+		return nil, errors.New("user ID is empty")
 	case options == nil:
 		options = map[string]interface{}{}
 	}
@@ -461,10 +489,10 @@ func (ch *Channel) BanUser(ctx context.Context, targetID, userID string, options
 }
 
 // UnBanUser removes the ban for target user ID on this channel.
-func (ch *Channel) UnBanUser(ctx context.Context, targetID string, options map[string]string) error {
+func (ch *Channel) UnBanUser(ctx context.Context, targetID string, options map[string]string) (*Response, error) {
 	switch {
 	case targetID == "":
-		return errors.New("target ID must be not empty")
+		return nil, errors.New("target ID must be not empty")
 	case options == nil:
 		options = map[string]string{}
 	}
@@ -478,7 +506,7 @@ func (ch *Channel) UnBanUser(ctx context.Context, targetID string, options map[s
 // ShadowBan shadow bans userID from this channel
 // bannedByID: user who shadow bans userID.
 // options: additional shadow ban options, ie {"timeout": 3600, "reason": "offensive language is not allowed here"}.
-func (ch *Channel) ShadowBan(ctx context.Context, userID, bannedByID string, options map[string]interface{}) error {
+func (ch *Channel) ShadowBan(ctx context.Context, userID, bannedByID string, options map[string]interface{}) (*Response, error) {
 	if options == nil {
 		options = map[string]interface{}{}
 	}
@@ -490,7 +518,7 @@ func (ch *Channel) ShadowBan(ctx context.Context, userID, bannedByID string, opt
 }
 
 // RemoveShadowBan removes the shadow ban for target user ID on this channel.
-func (ch *Channel) RemoveShadowBan(ctx context.Context, userID string) error {
+func (ch *Channel) RemoveShadowBan(ctx context.Context, userID string) (*Response, error) {
 	options := map[string]string{
 		"type": ch.Type,
 		"id":   ch.ID,
@@ -500,7 +528,7 @@ func (ch *Channel) RemoveShadowBan(ctx context.Context, userID string) error {
 }
 
 // Query fills channel info with state (messages, members, reads).
-func (ch *Channel) Query(ctx context.Context, data map[string]interface{}) error {
+func (ch *Channel) Query(ctx context.Context, data map[string]interface{}) (*Response, error) {
 	options := map[string]interface{}{
 		"state": true,
 	}
@@ -509,37 +537,48 @@ func (ch *Channel) Query(ctx context.Context, data map[string]interface{}) error
 }
 
 // Show makes channel visible for userID.
-func (ch *Channel) Show(ctx context.Context, userID string) error {
+func (ch *Channel) Show(ctx context.Context, userID string) (*Response, error) {
 	data := map[string]interface{}{
 		"user_id": userID,
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "show")
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
+	return &resp, err
 }
 
 // Hide makes channel hidden for userID.
-func (ch *Channel) Hide(ctx context.Context, userID string) error {
+func (ch *Channel) Hide(ctx context.Context, userID string) (*Response, error) {
 	return ch.hide(ctx, userID, false)
 }
 
 // HideWithHistoryClear clear marks channel as hidden and remove all messages for user.
-func (ch *Channel) HideWithHistoryClear(ctx context.Context, userID string) error {
+func (ch *Channel) HideWithHistoryClear(ctx context.Context, userID string) (*Response, error) {
 	return ch.hide(ctx, userID, true)
 }
 
-func (ch *Channel) hide(ctx context.Context, userID string, clearHistory bool) error {
+func (ch *Channel) hide(ctx context.Context, userID string, clearHistory bool) (*Response, error) {
 	data := map[string]interface{}{
 		"user_id":       userID,
 		"clear_history": clearHistory,
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "hide")
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
+	return &resp, err
+}
+
+type CreateChannelResponse struct {
+	Channel *Channel
+	*Response
 }
 
 // CreateChannel creates new channel of given type and id or returns already created one.
-func (c *Client) CreateChannel(ctx context.Context, chanType, chanID, userID string, data map[string]interface{}) (*Channel, error) {
+func (c *Client) CreateChannel(ctx context.Context, chanType, chanID, userID string, data map[string]interface{}) (*CreateChannelResponse, error) {
 	_, membersPresent := data["members"]
 
 	switch {
@@ -570,10 +609,11 @@ func (c *Client) CreateChannel(ctx context.Context, chanType, chanID, userID str
 
 	data["created_by"] = map[string]string{"id": userID}
 
-	if err := ch.query(ctx, options, data); err != nil {
+	resp, err := ch.query(ctx, options, data)
+	if err != nil {
 		return nil, err
 	}
-	return ch, nil
+	return &CreateChannelResponse{Channel: ch, Response: resp}, nil
 }
 
 type SendFileRequest struct {
@@ -587,40 +627,46 @@ type SendFileRequest struct {
 }
 
 // SendFile sends file to the channel. Returns file url or error.
-func (ch *Channel) SendFile(ctx context.Context, request SendFileRequest) (string, error) {
+func (ch *Channel) SendFile(ctx context.Context, request SendFileRequest) (*SendFileResponse, error) {
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "file")
 
 	return ch.client.sendFile(ctx, p, request)
 }
 
 // SendFile sends image to the channel. Returns file url or error.
-func (ch *Channel) SendImage(ctx context.Context, request SendFileRequest) (string, error) {
+func (ch *Channel) SendImage(ctx context.Context, request SendFileRequest) (*SendFileResponse, error) {
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "image")
 
 	return ch.client.sendFile(ctx, p, request)
 }
 
 // DeleteFile removes uploaded file.
-func (ch *Channel) DeleteFile(ctx context.Context, location string) error {
+func (ch *Channel) DeleteFile(ctx context.Context, location string) (*Response, error) {
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "file")
 
 	params := url.Values{}
 	params.Set("url", location)
-	return ch.client.makeRequest(ctx, http.MethodDelete, p, params, nil, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodDelete, p, params, nil, &resp)
+	return &resp, err
 }
 
 // DeleteImage removes uploaded image.
-func (ch *Channel) DeleteImage(ctx context.Context, location string) error {
+func (ch *Channel) DeleteImage(ctx context.Context, location string) (*Response, error) {
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "image")
 
 	params := url.Values{}
 	params.Set("url", location)
-	return ch.client.makeRequest(ctx, http.MethodDelete, p, params, nil, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodDelete, p, params, nil, &resp)
+	return &resp, err
 }
 
-func (ch *Channel) AcceptInvite(ctx context.Context, userID string, message *Message) error {
+func (ch *Channel) AcceptInvite(ctx context.Context, userID string, message *Message) (*Response, error) {
 	if userID == "" {
-		return errors.New("user ID must be not empty")
+		return nil, errors.New("user ID must be not empty")
 	}
 
 	data := map[string]interface{}{
@@ -633,12 +679,15 @@ func (ch *Channel) AcceptInvite(ctx context.Context, userID string, message *Mes
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
+	return &resp, err
 }
 
-func (ch *Channel) RejectInvite(ctx context.Context, userID string, message *Message) error {
+func (ch *Channel) RejectInvite(ctx context.Context, userID string, message *Message) (*Response, error) {
 	if userID == "" {
-		return errors.New("user ID must be not empty")
+		return nil, errors.New("user ID must be not empty")
 	}
 
 	data := map[string]interface{}{
@@ -651,7 +700,15 @@ func (ch *Channel) RejectInvite(ctx context.Context, userID string, message *Mes
 	}
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, nil)
+
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, data, &resp)
+	return &resp, err
+}
+
+type ChannelMuteResponse struct {
+	ChannelMute ChannelMute `json:"channel_mute"`
+	Response
 }
 
 func (ch *Channel) Mute(ctx context.Context, userID string, expiration *time.Duration) (*ChannelMuteResponse, error) {
@@ -672,23 +729,17 @@ func (ch *Channel) Mute(ctx context.Context, userID string, expiration *time.Dur
 	return mute, err
 }
 
-func (ch *Channel) Unmute(ctx context.Context, userID string) error {
+func (ch *Channel) Unmute(ctx context.Context, userID string) (*Response, error) {
 	if userID == "" {
-		return errors.New("user ID must be not empty")
+		return nil, errors.New("user ID must be not empty")
 	}
 
 	data := map[string]interface{}{
 		"user_id":     userID,
 		"channel_cid": ch.cid(),
 	}
-	return ch.client.makeRequest(ctx, http.MethodPost, "moderation/unmute/channel", nil, data, nil)
-}
 
-func (ch *Channel) refresh(ctx context.Context) error {
-	options := map[string]interface{}{
-		"watch":    false,
-		"state":    true,
-		"presence": false,
-	}
-	return ch.query(ctx, options, nil)
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, "moderation/unmute/channel", nil, data, &resp)
+	return &resp, err
 }

--- a/channel.go
+++ b/channel.go
@@ -174,7 +174,7 @@ func (ch *Channel) PartialUpdate(ctx context.Context, update PartialUpdate) (*Re
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID))
 
 	var resp Response
-	err := ch.client.makeRequest(ctx, http.MethodPatch, p, nil, update, nil)
+	err := ch.client.makeRequest(ctx, http.MethodPatch, p, nil, update, &resp)
 	return &resp, err
 }
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -266,8 +266,10 @@ func TestChannel_GetReplies(t *testing.T) {
 
 	msg := &Message{Text: "test message"}
 
-	msg, err := ch.SendMessage(context.Background(), msg, randomUser(t, c).ID, MessageSkipPush)
+	resp, err := ch.SendMessage(context.Background(), msg, randomUser(t, c).ID, MessageSkipPush)
 	require.NoError(t, err, "send message")
+
+	msg = resp.Message
 
 	reply := &Message{Text: "test reply", ParentID: msg.ID, Type: MessageTypeReply}
 	_, err = ch.SendMessage(context.Background(), reply, randomUser(t, c).ID)
@@ -318,9 +320,11 @@ func TestChannel_SendMessage(t *testing.T) {
 		User: user1,
 	}
 
-	msg, err := ch.SendMessage(context.Background(), msg, user2.ID)
+	resp, err := ch.SendMessage(context.Background(), msg, user2.ID)
 	require.NoError(t, err, "send message")
+
 	// check that message was updated
+	msg = resp.Message
 	assert.NotEmpty(t, msg.ID, "message has ID")
 	assert.NotEmpty(t, msg.HTML, "message has HTML body")
 
@@ -329,9 +333,11 @@ func TestChannel_SendMessage(t *testing.T) {
 		User:   user1,
 		Silent: true,
 	}
-	msg2, err = ch.SendMessage(context.Background(), msg2, user2.ID)
+	resp, err = ch.SendMessage(context.Background(), msg2, user2.ID)
 	require.NoError(t, err, "send message 2")
+
 	// check that message was updated
+	msg2 = resp.Message
 	assert.NotEmpty(t, msg2.ID, "message has ID")
 	assert.NotEmpty(t, msg2.HTML, "message has HTML body")
 	assert.True(t, msg2.Silent, "message silent flag is set")
@@ -351,10 +357,10 @@ func TestChannel_Truncate(t *testing.T) {
 	}
 
 	// Make sure we have one message in the channel
-	msg, err := ch.SendMessage(context.Background(), msg, user.ID)
+	resp, err := ch.SendMessage(context.Background(), msg, user.ID)
 	require.NoError(t, err, "send message")
 	require.NoError(t, ch.refresh(context.Background()), "refresh channel")
-	assert.Equal(t, ch.Messages[0].ID, msg.ID, "message exists")
+	assert.Equal(t, ch.Messages[0].ID, resp.Message.ID, "message exists")
 
 	// Now truncate it
 	err = ch.Truncate(context.Background())
@@ -377,10 +383,10 @@ func TestChannel_TruncateWithOptions(t *testing.T) {
 	}
 
 	// Make sure we have one message in the channel
-	msg, err := ch.SendMessage(context.Background(), msg, user.ID)
+	resp, err := ch.SendMessage(context.Background(), msg, user.ID)
 	require.NoError(t, err, "send message")
 	require.NoError(t, ch.refresh(context.Background()), "refresh channel")
-	assert.Equal(t, ch.Messages[0].ID, msg.ID, "message exists")
+	assert.Equal(t, ch.Messages[0].ID, resp.Message.ID, "message exists")
 
 	// Now truncate it
 	err = ch.Truncate(context.Background(),

--- a/channel_test.go
+++ b/channel_test.go
@@ -299,9 +299,9 @@ func TestChannel_GetReplies(t *testing.T) {
 	_, err = ch.SendMessage(context.Background(), reply, randomUser(t, c).ID)
 	require.NoError(t, err, "send reply")
 
-	replies, err := ch.GetReplies(context.Background(), msg.ID, nil)
+	repliesResp, err := ch.GetReplies(context.Background(), msg.ID, nil)
 	require.NoError(t, err, "get replies")
-	assert.Len(t, replies, 1)
+	assert.Len(t, repliesResp.Messages, 1)
 }
 
 func TestChannel_MarkRead(t *testing.T) {

--- a/channel_test.go
+++ b/channel_test.go
@@ -523,7 +523,6 @@ func TestChannel_SendImage(t *testing.T) {
 			User:        randomUser(t, c),
 			ContentType: "image/jpeg",
 		})
-
 		if err != nil {
 			t.Fatalf("Send image failed: %s", err.Error())
 		}

--- a/channel_test.go
+++ b/channel_test.go
@@ -605,13 +605,15 @@ func TestChannel_Mute_Unmute(t *testing.T) {
 	require.Equal(t, ch.CID, mute.ChannelMute.Channel.CID)
 	require.Equal(t, members[0], mute.ChannelMute.User.ID)
 	// query for muted the channel
-	channels, err := c.QueryChannels(context.Background(), &QueryOption{
+	queryChannResp, err := c.QueryChannels(context.Background(), &QueryOption{
 		UserID: members[0],
 		Filter: map[string]interface{}{
 			"muted": true,
 			"cid":   ch.CID,
 		},
 	})
+
+	channels := queryChannResp.Channels
 	require.NoError(t, err, "query muted channel")
 	require.Len(t, channels, 1)
 	require.Equal(t, channels[0].CID, ch.CID)
@@ -621,15 +623,16 @@ func TestChannel_Mute_Unmute(t *testing.T) {
 	require.NoError(t, err, "mute channel")
 
 	// query for unmuted the channel should return 1 results
-	channels, err = c.QueryChannels(context.Background(), &QueryOption{
+	queryChannResp, err = c.QueryChannels(context.Background(), &QueryOption{
 		UserID: members[0],
 		Filter: map[string]interface{}{
 			"muted": false,
 			"cid":   ch.CID,
 		},
 	})
+
 	require.NoError(t, err, "query muted channel")
-	require.Len(t, channels, 1)
+	require.Len(t, queryChannResp.Channels, 1)
 }
 
 func ExampleChannel_Update() {

--- a/channel_type.go
+++ b/channel_type.go
@@ -116,7 +116,6 @@ func (c *Client) CreateChannelType(ctx context.Context, chType *ChannelType) (*C
 		return nil, errors.New("unexpected error: channel type response is nil")
 	}
 
-	// TODO: check if we can get rid of this
 	for _, cmd := range resp.Commands {
 		resp.ChannelType.Commands = append(resp.ChannelType.Commands, &Command{Name: cmd})
 	}

--- a/channel_type.go
+++ b/channel_type.go
@@ -89,17 +89,24 @@ type channelTypeRequest struct {
 	UpdatedAt time.Time `json:"-"`
 }
 
-type channelTypeResponse struct {
-	ChannelTypes map[string]*ChannelType `json:"channel_types"`
+type ChannelTypeResponse struct {
+	*ChannelType
+
+	Commands []string `json:"commands"`
+
+	CreatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"-"`
+
+	Response
 }
 
 // CreateChannelType adds new channel type.
-func (c *Client) CreateChannelType(ctx context.Context, chType *ChannelType) (*ChannelType, error) {
+func (c *Client) CreateChannelType(ctx context.Context, chType *ChannelType) (*ChannelTypeResponse, error) {
 	if chType == nil {
 		return nil, errors.New("channel type is nil")
 	}
 
-	var resp channelTypeRequest
+	var resp ChannelTypeResponse
 
 	err := c.makeRequest(ctx, http.MethodPost, "channeltypes", nil, chType.toRequest(), &resp)
 	if err != nil {
@@ -109,52 +116,65 @@ func (c *Client) CreateChannelType(ctx context.Context, chType *ChannelType) (*C
 		return nil, errors.New("unexpected error: channel type response is nil")
 	}
 
+	// TODO: check if we can get rid of this
 	for _, cmd := range resp.Commands {
 		resp.ChannelType.Commands = append(resp.ChannelType.Commands, &Command{Name: cmd})
 	}
 
-	return resp.ChannelType, nil
+	return &resp, nil
+}
+
+type GetChannelTypeResponse struct {
+	*ChannelType
+	Response
 }
 
 // GetChannelType returns information about channel type.
-func (c *Client) GetChannelType(ctx context.Context, chanType string) (*ChannelType, error) {
+func (c *Client) GetChannelType(ctx context.Context, chanType string) (*GetChannelTypeResponse, error) {
 	if chanType == "" {
 		return nil, errors.New("channel type is empty")
 	}
 
 	p := path.Join("channeltypes", url.PathEscape(chanType))
 
-	ct := ChannelType{}
+	var resp GetChannelTypeResponse
+	err := c.makeRequest(ctx, http.MethodGet, p, nil, nil, &resp)
+	return &resp, err
+}
 
-	err := c.makeRequest(ctx, http.MethodGet, p, nil, nil, &ct)
-	return &ct, err
+type ChannelTypesResponse struct {
+	ChannelTypes map[string]*ChannelType `json:"channel_types"`
+	Response
 }
 
 // ListChannelTypes returns all channel types.
-func (c *Client) ListChannelTypes(ctx context.Context) (map[string]*ChannelType, error) {
-	var resp channelTypeResponse
-
+func (c *Client) ListChannelTypes(ctx context.Context) (*ChannelTypesResponse, error) {
+	var resp ChannelTypesResponse
 	err := c.makeRequest(ctx, http.MethodGet, "channeltypes", nil, nil, &resp)
-	return resp.ChannelTypes, err
+	return &resp, err
 }
 
-func (c *Client) UpdateChannelType(ctx context.Context, name string, options map[string]interface{}) error {
+func (c *Client) UpdateChannelType(ctx context.Context, name string, options map[string]interface{}) (*Response, error) {
 	switch {
 	case name == "":
-		return errors.New("channel type name is empty")
+		return nil, errors.New("channel type name is empty")
 	case len(options) == 0:
-		return errors.New("options are empty")
+		return nil, errors.New("options are empty")
 	}
 
 	p := path.Join("channeltypes", url.PathEscape(name))
-	return c.makeRequest(ctx, http.MethodPut, p, nil, options, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPut, p, nil, options, &resp)
+	return &resp, err
 }
 
-func (c *Client) DeleteChannelType(ctx context.Context, name string) error {
+func (c *Client) DeleteChannelType(ctx context.Context, name string) (*Response, error) {
 	if name == "" {
-		return errors.New("channel type name is empty")
+		return nil, errors.New("channel type name is empty")
 	}
 
 	p := path.Join("channeltypes", url.PathEscape(name))
-	return c.makeRequest(ctx, http.MethodDelete, p, nil, nil, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodDelete, p, nil, nil, &resp)
+	return &resp, err
 }

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -12,12 +12,12 @@ import (
 func prepareChannelType(t *testing.T, c *Client) *ChannelType {
 	ct := NewChannelType(randomString(10))
 
-	ct, err := c.CreateChannelType(context.Background(), ct)
+	resp, err := c.CreateChannelType(context.Background(), ct)
 	require.NoError(t, err, "create channel type")
 
 	time.Sleep(6 * time.Second)
 
-	return ct
+	return resp.ChannelType
 }
 
 func TestClient_GetChannelType(t *testing.T) {
@@ -25,15 +25,15 @@ func TestClient_GetChannelType(t *testing.T) {
 
 	ct := prepareChannelType(t, c)
 	defer func() {
-		_ = c.DeleteChannelType(context.Background(), ct.Name)
+		_, _ = c.DeleteChannelType(context.Background(), ct.Name)
 	}()
 
-	got, err := c.GetChannelType(context.Background(), ct.Name)
+	resp, err := c.GetChannelType(context.Background(), ct.Name)
 	require.NoError(t, err, "get channel type")
 
-	assert.Equal(t, ct.Name, got.Name)
-	assert.Equal(t, len(ct.Commands), len(got.Commands))
-	assert.Equal(t, ct.Permissions, got.Permissions)
+	assert.Equal(t, ct.Name, resp.ChannelType.Name)
+	assert.Equal(t, len(ct.Commands), len(resp.ChannelType.Commands))
+	assert.Equal(t, ct.Permissions, resp.ChannelType.Permissions)
 }
 
 func TestClient_ListChannelTypes(t *testing.T) {
@@ -41,13 +41,13 @@ func TestClient_ListChannelTypes(t *testing.T) {
 
 	ct := prepareChannelType(t, c)
 	defer func() {
-		_ = c.DeleteChannelType(context.Background(), ct.Name)
+		_, _ = c.DeleteChannelType(context.Background(), ct.Name)
 	}()
 
-	got, err := c.ListChannelTypes(context.Background())
+	resp, err := c.ListChannelTypes(context.Background())
 	require.NoError(t, err, "list channel types")
 
-	assert.Contains(t, got, ct.Name)
+	assert.Contains(t, resp.ChannelTypes, ct.Name)
 }
 
 func TestClient_UpdateChannelTypePushNotifications(t *testing.T) {
@@ -55,18 +55,18 @@ func TestClient_UpdateChannelTypePushNotifications(t *testing.T) {
 
 	ct := prepareChannelType(t, c)
 	defer func() {
-		_ = c.DeleteChannelType(context.Background(), ct.Name)
+		_, _ = c.DeleteChannelType(context.Background(), ct.Name)
 	}()
 
 	// default is on
 	require.True(t, ct.PushNotifications)
 
-	err := c.UpdateChannelType(context.Background(), ct.Name, map[string]interface{}{"push_notifications": false})
+	_, err := c.UpdateChannelType(context.Background(), ct.Name, map[string]interface{}{"push_notifications": false})
 	require.NoError(t, err)
 
-	updated, err := c.GetChannelType(context.Background(), ct.Name)
+	resp, err := c.GetChannelType(context.Background(), ct.Name)
 	require.NoError(t, err)
-	require.False(t, updated.PushNotifications)
+	require.False(t, resp.ChannelType.PushNotifications)
 }
 
 // See https://getstream.io/chat/docs/channel_features/ for more details.
@@ -112,7 +112,7 @@ func ExampleClient_GetChannelType() {
 func ExampleClient_UpdateChannelType() {
 	client := &Client{}
 
-	_ = client.UpdateChannelType(context.Background(), "public", map[string]interface{}{
+	_, _ = client.UpdateChannelType(context.Background(), "public", map[string]interface{}{
 		"permissions": []map[string]interface{}{
 			{
 				"name":      "Allow reads for all",
@@ -137,7 +137,7 @@ func ExampleClient_UpdateChannelType() {
 func ExampleClient_UpdateChannelType_bool() {
 	client := &Client{}
 
-	_ = client.UpdateChannelType(context.Background(), "public", map[string]interface{}{
+	_, _ = client.UpdateChannelType(context.Background(), "public", map[string]interface{}{
 		"typing_events":  false,
 		"read_events":    true,
 		"connect_events": true,
@@ -151,7 +151,7 @@ func ExampleClient_UpdateChannelType_bool() {
 func ExampleClient_UpdateChannelType_other() {
 	client := &Client{}
 
-	_ = client.UpdateChannelType(context.Background(),
+	_, _ = client.UpdateChannelType(context.Background(),
 		"public",
 		map[string]interface{}{
 			"automod":            "disabled",
@@ -165,7 +165,7 @@ func ExampleClient_UpdateChannelType_other() {
 func ExampleClient_UpdateChannelType_permissions() {
 	client := &Client{}
 
-	_ = client.UpdateChannelType(context.Background(),
+	_, _ = client.UpdateChannelType(context.Background(),
 		"public",
 		map[string]interface{}{
 			"permissions": []map[string]interface{}{
@@ -190,5 +190,5 @@ func ExampleClient_UpdateChannelType_permissions() {
 func ExampleClient_DeleteChannelType() {
 	client := &Client{}
 
-	_ = client.DeleteChannelType(context.Background(), "public")
+	_, _ = client.DeleteChannelType(context.Background(), "public")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -2,7 +2,6 @@ package stream_chat // nolint: golint
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -82,73 +81,4 @@ func TestClient_CreateToken(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestSendUserCustomEvent(t *testing.T) {
-	c := initClient(t)
-
-	tests := []struct {
-		name         string
-		event        *UserCustomEvent
-		targetUserID string
-		expectedErr  string
-	}{
-		{
-			name: "ok",
-			event: &UserCustomEvent{
-				Type: "custom_event",
-			},
-			targetUserID: "user1",
-		},
-		{
-			name:         "error: event is nil",
-			event:        nil,
-			targetUserID: "user1",
-			expectedErr:  "event is nil",
-		},
-		{
-			name:         "error: empty targetUserID",
-			event:        &UserCustomEvent{},
-			targetUserID: "",
-			expectedErr:  "targetUserID should not be empty",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if test.expectedErr == "" {
-				_, err := c.UpsertUser(context.Background(), &User{ID: test.targetUserID})
-				require.NoError(t, err)
-			}
-
-			err := c.SendUserCustomEvent(context.Background(), test.targetUserID, test.event)
-
-			if test.expectedErr == "" {
-				require.NoError(t, err)
-				return
-			}
-			require.EqualError(t, err, test.expectedErr)
-		})
-	}
-}
-
-func TestMarshalUnmarshalUserCustomEvent(t *testing.T) {
-	ev1 := UserCustomEvent{
-		Type: "custom_event",
-		ExtraData: map[string]interface{}{
-			"name":   "John Doe",
-			"age":    99.0,
-			"hungry": true,
-			"fruits": []interface{}{},
-		},
-	}
-
-	b, err := json.Marshal(ev1)
-	require.NoError(t, err)
-
-	ev2 := UserCustomEvent{}
-	err = json.Unmarshal(b, &ev2)
-	require.NoError(t, err)
-
-	require.Equal(t, ev1, ev2)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -24,12 +24,12 @@ func initClient(t *testing.T) *Client {
 
 func initChannel(t *testing.T, c *Client, membersID ...string) *Channel {
 	owner := randomUser(t, c)
-	ch, err := c.CreateChannel(context.Background(), "team", randomString(12), owner.ID, map[string]interface{}{
+	resp, err := c.CreateChannel(context.Background(), "team", randomString(12), owner.ID, map[string]interface{}{
 		"members": membersID,
 	})
 
 	require.NoError(t, err, "create channel")
-	return ch
+	return resp.Channel
 }
 
 func TestNewClient(t *testing.T) {

--- a/command_test.go
+++ b/command_test.go
@@ -14,10 +14,10 @@ func prepareCommand(t *testing.T, c *Client) *Command {
 		Description: "test command",
 	}
 
-	cmd, err := c.CreateCommand(context.Background(), cmd)
+	resp, err := c.CreateCommand(context.Background(), cmd)
 	require.NoError(t, err, "create command")
 
-	return cmd
+	return resp.Command
 }
 
 func TestClient_GetCommand(t *testing.T) {
@@ -25,14 +25,14 @@ func TestClient_GetCommand(t *testing.T) {
 
 	cmd := prepareCommand(t, c)
 	defer func() {
-		_ = c.DeleteCommand(context.Background(), cmd.Name)
+		_, _ = c.DeleteCommand(context.Background(), cmd.Name)
 	}()
 
-	got, err := c.GetCommand(context.Background(), cmd.Name)
+	resp, err := c.GetCommand(context.Background(), cmd.Name)
 	require.NoError(t, err, "get command")
 
-	assert.Equal(t, cmd.Name, got.Name)
-	assert.Equal(t, cmd.Description, got.Description)
+	assert.Equal(t, cmd.Name, resp.Command.Name)
+	assert.Equal(t, cmd.Description, resp.Command.Description)
 }
 
 func TestClient_ListCommands(t *testing.T) {
@@ -40,13 +40,13 @@ func TestClient_ListCommands(t *testing.T) {
 
 	cmd := prepareCommand(t, c)
 	defer func() {
-		_ = c.DeleteCommand(context.Background(), cmd.Name)
+		_, _ = c.DeleteCommand(context.Background(), cmd.Name)
 	}()
 
-	got, err := c.ListCommands(context.Background())
+	resp, err := c.ListCommands(context.Background())
 	require.NoError(t, err, "list commands")
 
-	assert.Contains(t, got, cmd)
+	assert.Contains(t, resp.Commands, cmd)
 }
 
 func TestClient_UpdateCommand(t *testing.T) {
@@ -54,16 +54,16 @@ func TestClient_UpdateCommand(t *testing.T) {
 
 	cmd := prepareCommand(t, c)
 	defer func() {
-		_ = c.DeleteCommand(context.Background(), cmd.Name)
+		_, _ = c.DeleteCommand(context.Background(), cmd.Name)
 	}()
 
-	got, err := c.UpdateCommand(context.Background(), cmd.Name, map[string]interface{}{
+	resp, err := c.UpdateCommand(context.Background(), cmd.Name, map[string]interface{}{
 		"description": "new description",
 	})
 	require.NoError(t, err, "update command")
 
-	assert.Equal(t, cmd.Name, got.Name)
-	assert.Equal(t, "new description", got.Description)
+	assert.Equal(t, cmd.Name, resp.Command.Name)
+	assert.Equal(t, "new description", resp.Command.Description)
 }
 
 // See https://getstream.io/chat/docs/custom_commands/ for more details.
@@ -101,5 +101,5 @@ func ExampleClient_UpdateCommand() {
 func ExampleClient_DeleteCommand() {
 	client := &Client{}
 
-	_ = client.DeleteCommand(context.Background(), "my-command")
+	_, _ = client.DeleteCommand(context.Background(), "my-command")
 }

--- a/device.go
+++ b/device.go
@@ -20,12 +20,13 @@ type Device struct {
 	PushProvider pushProvider `json:"push_provider"` // The push provider for this device. One of constants PushProvider*
 }
 
-type devicesResponse struct {
+type DevicesResponse struct {
 	Devices []*Device `json:"devices"`
+	Response
 }
 
 // GetDevices retrieves the list of devices for user.
-func (c *Client) GetDevices(ctx context.Context, userID string) (devices []*Device, err error) {
+func (c *Client) GetDevices(ctx context.Context, userID string) (*DevicesResponse, error) {
 	if userID == "" {
 		return nil, errors.New("user ID is empty")
 	}
@@ -33,39 +34,44 @@ func (c *Client) GetDevices(ctx context.Context, userID string) (devices []*Devi
 	params := url.Values{}
 	params.Set("user_id", userID)
 
-	var resp devicesResponse
+	var resp DevicesResponse
 
-	err = c.makeRequest(ctx, http.MethodGet, "devices", params, nil, &resp)
-	return resp.Devices, err
+	err := c.makeRequest(ctx, http.MethodGet, "devices", params, nil, &resp)
+	return &resp, err
 }
 
 // AddDevice adds new device.
-func (c *Client) AddDevice(ctx context.Context, device *Device) error {
+func (c *Client) AddDevice(ctx context.Context, device *Device) (*Response, error) {
 	switch {
 	case device == nil:
-		return errors.New("device is nil")
+		return nil, errors.New("device is nil")
 	case device.ID == "":
-		return errors.New("device ID is empty")
+		return nil, errors.New("device ID is empty")
 	case device.UserID == "":
-		return errors.New("device user ID is empty")
+		return nil, errors.New("device user ID is empty")
 	case device.PushProvider == "":
-		return errors.New("device push provider is empty")
+		return nil, errors.New("device push provider is empty")
 	}
 
-	return c.makeRequest(ctx, http.MethodPost, "devices", nil, device, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, "devices", nil, device, &resp)
+	return &resp, err
 }
 
 // DeleteDevice deletes a device from the user.
-func (c *Client) DeleteDevice(ctx context.Context, userID, deviceID string) error {
+func (c *Client) DeleteDevice(ctx context.Context, userID, deviceID string) (*Response, error) {
 	switch {
 	case userID == "":
-		return errors.New("user ID is empty")
+		return nil, errors.New("user ID is empty")
 	case deviceID == "":
-		return errors.New("device ID is empty")
+		return nil, errors.New("device ID is empty")
 	}
 
 	params := url.Values{}
 	params.Set("id", deviceID)
 	params.Set("user_id", userID)
-	return c.makeRequest(ctx, http.MethodDelete, "devices", params, nil, nil)
+
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodDelete, "devices", params, nil, &resp)
+	return &resp, err
 }

--- a/device_test.go
+++ b/device_test.go
@@ -19,15 +19,17 @@ func TestClient_Devices(t *testing.T) {
 	}
 
 	for _, dev := range devices {
-		require.NoError(t, c.AddDevice(context.Background(), dev), "add device")
+		_, err := c.AddDevice(context.Background(), dev)
+		require.NoError(t, err, "add device")
 		defer func(dev *Device) {
-			require.NoError(t, c.DeleteDevice(context.Background(), user.ID, dev.ID), "delete device")
+			_, err := c.DeleteDevice(context.Background(), user.ID, dev.ID)
+			require.NoError(t, err, "delete device")
 		}(dev)
 
 		resp, err := c.GetDevices(context.Background(), user.ID)
 		require.NoError(t, err, "get devices")
 
-		assert.True(t, deviceIDExists(resp, dev.ID), "device with ID %s was created", dev.ID)
+		assert.True(t, deviceIDExists(resp.Devices, dev.ID), "device with ID %s was created", dev.ID)
 	}
 }
 
@@ -43,7 +45,7 @@ func deviceIDExists(dev []*Device, id string) bool {
 func ExampleClient_AddDevice() {
 	client, _ := NewClient("XXXX", "XXXX")
 
-	_ = client.AddDevice(context.Background(), &Device{
+	_, _ = client.AddDevice(context.Background(), &Device{
 		ID:           "2ffca4ad6599adc9b5202d15a5286d33c19547d472cd09de44219cda5ac30207",
 		UserID:       "elon",
 		PushProvider: PushProviderAPNS,
@@ -55,5 +57,5 @@ func ExampleClient_DeleteDevice() {
 
 	deviceID := "2ffca4ad6599adc9b5202d15a5286d33c19547d472cd09de44219cda5ac30207"
 	userID := "elon"
-	_ = client.DeleteDevice(context.Background(), userID, deviceID)
+	_, _ = client.DeleteDevice(context.Background(), userID, deviceID)
 }

--- a/event.go
+++ b/event.go
@@ -113,9 +113,9 @@ func (e Event) MarshalJSON() ([]byte, error) {
 }
 
 // SendEvent sends an event on this channel.
-func (ch *Channel) SendEvent(ctx context.Context, event *Event, userID string) error {
+func (ch *Channel) SendEvent(ctx context.Context, event *Event, userID string) (*Response, error) {
 	if event == nil {
-		return errors.New("event is nil")
+		return nil, errors.New("event is nil")
 	}
 
 	event.User = &User{ID: userID}
@@ -128,7 +128,9 @@ func (ch *Channel) SendEvent(ctx context.Context, event *Event, userID string) e
 
 	p := path.Join("channels", url.PathEscape(ch.Type), url.PathEscape(ch.ID), "event")
 
-	return ch.client.makeRequest(ctx, http.MethodPost, p, nil, req, nil)
+	var resp Response
+	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, req, &resp)
+	return &resp, err
 }
 
 // UserCustomEvent is a custom event sent to a particular user.
@@ -164,12 +166,12 @@ func (e UserCustomEvent) MarshalJSON() ([]byte, error) {
 }
 
 // SendUserCustomEvent sends a custom event to all connected clients for the target user id.
-func (c *Client) SendUserCustomEvent(ctx context.Context, targetUserID string, event *UserCustomEvent) error {
+func (c *Client) SendUserCustomEvent(ctx context.Context, targetUserID string, event *UserCustomEvent) (*Response, error) {
 	if event == nil {
-		return errors.New("event is nil")
+		return nil, errors.New("event is nil")
 	}
 	if targetUserID == "" {
-		return errors.New("targetUserID should not be empty")
+		return nil, errors.New("targetUserID should not be empty")
 	}
 
 	req := struct {
@@ -179,5 +181,8 @@ func (c *Client) SendUserCustomEvent(ctx context.Context, targetUserID string, e
 	}
 
 	p := path.Join("users", url.PathEscape(targetUserID), "event")
-	return c.makeRequest(ctx, http.MethodPost, p, nil, req, nil)
+
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, p, nil, req, &resp)
+	return &resp, err
 }

--- a/event_test.go
+++ b/event_test.go
@@ -2,10 +2,12 @@ package stream_chat // nolint: golint
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestEventSupportsAllFields that we can decode all of the keys in the
@@ -40,4 +42,73 @@ func TestEventSupportsAllFields(t *testing.T) {
 
 		assert.Equal(t, name, result.Type)
 	}
+}
+
+func TestSendUserCustomEvent(t *testing.T) {
+	c := initClient(t)
+
+	tests := []struct {
+		name         string
+		event        *UserCustomEvent
+		targetUserID string
+		expectedErr  string
+	}{
+		{
+			name: "ok",
+			event: &UserCustomEvent{
+				Type: "custom_event",
+			},
+			targetUserID: "user1",
+		},
+		{
+			name:         "error: event is nil",
+			event:        nil,
+			targetUserID: "user1",
+			expectedErr:  "event is nil",
+		},
+		{
+			name:         "error: empty targetUserID",
+			event:        &UserCustomEvent{},
+			targetUserID: "",
+			expectedErr:  "targetUserID should not be empty",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.expectedErr == "" {
+				_, err := c.UpsertUser(context.Background(), &User{ID: test.targetUserID})
+				require.NoError(t, err)
+			}
+
+			_, err := c.SendUserCustomEvent(context.Background(), test.targetUserID, test.event)
+
+			if test.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, test.expectedErr)
+		})
+	}
+}
+
+func TestMarshalUnmarshalUserCustomEvent(t *testing.T) {
+	ev1 := UserCustomEvent{
+		Type: "custom_event",
+		ExtraData: map[string]interface{}{
+			"name":   "John Doe",
+			"age":    99.0,
+			"hungry": true,
+			"fruits": []interface{}{},
+		},
+	}
+
+	b, err := json.Marshal(ev1)
+	require.NoError(t, err)
+
+	ev2 := UserCustomEvent{}
+	err = json.Unmarshal(b, &ev2)
+	require.NoError(t, err)
+
+	require.Equal(t, ev1, ev2)
 }

--- a/http.go
+++ b/http.go
@@ -60,6 +60,7 @@ func (c *Client) parseResponse(resp *http.Response, result interface{}) error {
 		return apiErr
 	}
 
+	//TODO: do not unmarshal if there is nothing to unmarshal to
 	err = json.Unmarshal(b, result)
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal body: %w", err)

--- a/http.go
+++ b/http.go
@@ -60,10 +60,13 @@ func (c *Client) parseResponse(resp *http.Response, result interface{}) error {
 		return apiErr
 	}
 
-	//TODO: do not unmarshal if there is nothing to unmarshal to
-	err = json.Unmarshal(b, result)
-	if err != nil {
-		return fmt.Errorf("cannot unmarshal body: %w", err)
+	_, ok := result.(*Response)
+	if !ok {
+		// Unmarshal the body only when it is expected.
+		err = json.Unmarshal(b, result)
+		if err != nil {
+			return fmt.Errorf("cannot unmarshal body: %w", err)
+		}
 	}
 
 	return c.addRateLimitInfo(resp.Header, result)

--- a/http_test.go
+++ b/http_test.go
@@ -30,7 +30,7 @@ func TestRateLimit(t *testing.T) {
 			require.Equal(t, http.StatusTooManyRequests, apiErr.StatusCode)
 			require.NotZero(t, apiErr.RateLimit.Limit)
 			require.NotZero(t, apiErr.RateLimit.Reset)
-			require.Equal(t, 0, apiErr.RateLimit.Remaining)
+			require.EqualValues(t, 0, apiErr.RateLimit.Remaining)
 			return
 		}
 	}

--- a/message.go
+++ b/message.go
@@ -194,8 +194,14 @@ func MessageSkipPush(r *messageRequest) {
 	}
 }
 
+type MessageResponse struct {
+	Message *Message `json:"message"`
+
+	Response
+}
+
 // SendMessage sends a message to the channel. Returns full message details from server.
-func (ch *Channel) SendMessage(ctx context.Context, message *Message, userID string, options ...SendMessageOption) (*Message, error) {
+func (ch *Channel) SendMessage(ctx context.Context, message *Message, userID string, options ...SendMessageOption) (*MessageResponse, error) {
 	switch {
 	case message == nil:
 		return nil, errors.New("message is nil")
@@ -211,9 +217,9 @@ func (ch *Channel) SendMessage(ctx context.Context, message *Message, userID str
 		op(&req)
 	}
 
-	var resp messageResponse
+	var resp MessageResponse
 	err := ch.client.makeRequest(ctx, http.MethodPost, p, nil, req, &resp)
-	return resp.Message, err
+	return &resp, err
 }
 
 // MarkAllRead marks all messages as read for userID.

--- a/message.go
+++ b/message.go
@@ -140,10 +140,6 @@ type messageRequestUser struct {
 	ID string `json:"id"`
 }
 
-type messageResponse struct {
-	Message *Message `json:"message"`
-}
-
 type Attachment struct {
 	Type string `json:"type,omitempty"` // text, image, audio, video
 

--- a/message_test.go
+++ b/message_test.go
@@ -18,10 +18,10 @@ func TestClient_PinMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	msg := &Message{Text: "test message"}
-	msg, err = ch.SendMessage(context.Background(), msg, userB.ID)
+	resp, err := ch.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
 
-	msg, err = c.PinMessage(context.Background(), msg.ID, userA.ID, nil)
+	msg, err = c.PinMessage(context.Background(), resp.Message.ID, userA.ID, nil)
 	require.NoError(t, err)
 	require.NotZero(t, msg.PinnedAt)
 	require.NotZero(t, msg.PinnedBy)

--- a/message_test.go
+++ b/message_test.go
@@ -18,30 +18,38 @@ func TestClient_PinMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	msg := &Message{Text: "test message"}
-	resp2, err := resp1.Channel.SendMessage(context.Background(), msg, userB.ID)
+	messageResp, err := resp1.Channel.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
 
-	msg, err = c.PinMessage(context.Background(), resp2.Message.ID, userA.ID, nil)
+	messageResp, err = c.PinMessage(context.Background(), messageResp.Message.ID, userA.ID, nil)
 	require.NoError(t, err)
+
+	msg = messageResp.Message
 	require.NotZero(t, msg.PinnedAt)
 	require.NotZero(t, msg.PinnedBy)
 	require.Equal(t, userA.ID, msg.PinnedBy.ID)
 
-	msg, err = c.UnPinMessage(context.Background(), msg.ID, userA.ID)
+	messageResp, err = c.UnPinMessage(context.Background(), msg.ID, userA.ID)
 	require.NoError(t, err)
+
+	msg = messageResp.Message
 	require.Zero(t, msg.PinnedAt)
 	require.Zero(t, msg.PinnedBy)
 
 	expireAt := time.Now().Add(3 * time.Second)
-	msg, err = c.PinMessage(context.Background(), msg.ID, userA.ID, &expireAt)
+	messageResp, err = c.PinMessage(context.Background(), msg.ID, userA.ID, &expireAt)
 	require.NoError(t, err)
+
+	msg = messageResp.Message
 	require.NotZero(t, msg.PinnedAt)
 	require.NotZero(t, msg.PinnedBy)
 	require.Equal(t, userA.ID, msg.PinnedBy.ID)
 
 	time.Sleep(3 * time.Second)
-	msg, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(context.Background(), msg.ID)
 	require.NoError(t, err)
+
+	msg = messageResp.Message
 	require.Zero(t, msg.PinnedAt)
 	require.Zero(t, msg.PinnedBy)
 }

--- a/message_test.go
+++ b/message_test.go
@@ -14,14 +14,14 @@ func TestClient_PinMessage(t *testing.T) {
 	userB := randomUser(t, c)
 
 	ch := initChannel(t, c, userA.ID, userB.ID)
-	ch, err := c.CreateChannel(context.Background(), ch.Type, ch.ID, userA.ID, nil)
+	resp1, err := c.CreateChannel(context.Background(), ch.Type, ch.ID, userA.ID, nil)
 	require.NoError(t, err)
 
 	msg := &Message{Text: "test message"}
-	resp, err := ch.SendMessage(context.Background(), msg, userB.ID)
+	resp2, err := resp1.Channel.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
 
-	msg, err = c.PinMessage(context.Background(), resp.Message.ID, userA.ID, nil)
+	msg, err = c.PinMessage(context.Background(), resp2.Message.ID, userA.ID, nil)
 	require.NoError(t, err)
 	require.NotZero(t, msg.PinnedAt)
 	require.NotZero(t, msg.PinnedBy)

--- a/permission_client.go
+++ b/permission_client.go
@@ -20,14 +20,6 @@ type Permission struct {
 	Level       string                 `json:"level"`
 }
 
-type getPermissionResponse struct {
-	Permission *Permission `json:"permission"`
-}
-
-type listPermissionsResponse struct {
-	Permissions []*Permission `json:"permissions"`
-}
-
 type Role struct {
 	Name      string    `json:"name"`
 	Custom    bool      `json:"custom"`
@@ -36,82 +28,107 @@ type Role struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-type roleResponse struct {
-	Roles []*Role `json:"roles"`
-}
-
 type PermissionClient struct {
 	client *Client
 }
 
 // CreateRole creates a new role.
-func (p *PermissionClient) CreateRole(ctx context.Context, name string) error {
+func (p *PermissionClient) CreateRole(ctx context.Context, name string) (*Response, error) {
 	if name == "" {
-		return errors.New("name is required")
+		return nil, errors.New("name is required")
 	}
 
-	return p.client.makeRequest(ctx, http.MethodPost, "roles", nil, map[string]interface{}{
+	var resp Response
+	err := p.client.makeRequest(ctx, http.MethodPost, "roles", nil, map[string]interface{}{
 		"name": name,
-	}, nil)
+	}, &resp)
+	return &resp, err
 }
 
 // DeleteRole deletes an existing role by name.
-func (p *PermissionClient) DeleteRole(ctx context.Context, name string) error {
+func (p *PermissionClient) DeleteRole(ctx context.Context, name string) (*Response, error) {
 	if name == "" {
-		return errors.New("name is required")
+		return nil, errors.New("name is required")
 	}
 
 	uri := path.Join("roles", name)
-	return p.client.makeRequest(ctx, http.MethodDelete, uri, nil, nil, nil)
+
+	var resp Response
+	err := p.client.makeRequest(ctx, http.MethodDelete, uri, nil, nil, &resp)
+	return &resp, err
+}
+
+type RolesResponse struct {
+	Roles []*Role `json:"roles"`
+	Response
 }
 
 // ListRole returns all roles.
-func (p *PermissionClient) ListRoles(ctx context.Context) ([]*Role, error) {
-	var r roleResponse
+func (p *PermissionClient) ListRoles(ctx context.Context) (*RolesResponse, error) {
+	var r RolesResponse
 	err := p.client.makeRequest(ctx, http.MethodGet, "roles", nil, nil, &r)
-	return r.Roles, err
+	return &r, err
 }
 
 // CreatePermission creates a new permission.
-func (p *PermissionClient) CreatePermission(ctx context.Context, perm *Permission) error {
-	return p.client.makeRequest(ctx, http.MethodPost, "permissions", nil, perm, nil)
+func (p *PermissionClient) CreatePermission(ctx context.Context, perm *Permission) (*Response, error) {
+	var resp Response
+	err := p.client.makeRequest(ctx, http.MethodPost, "permissions", nil, perm, &resp)
+	return &resp, err
+}
+
+type GetPermissionResponse struct {
+	Permission *Permission `json:"permission"`
+	Response
 }
 
 // GetPermission returns a permission by id.
-func (p *PermissionClient) GetPermission(ctx context.Context, id string) (*Permission, error) {
+func (p *PermissionClient) GetPermission(ctx context.Context, id string) (*GetPermissionResponse, error) {
 	if id == "" {
 		return nil, errors.New("id is required")
 	}
 
-	var perm getPermissionResponse
 	uri := path.Join("permissions", id)
+
+	var perm GetPermissionResponse
 	err := p.client.makeRequest(ctx, http.MethodGet, uri, nil, nil, &perm)
-	return perm.Permission, err
+	return &perm, err
 }
 
 // UpdatePermission updates an existing permission by id. Only custom permissions can be updated.
-func (p *PermissionClient) UpdatePermission(ctx context.Context, id string, perm *Permission) error {
+func (p *PermissionClient) UpdatePermission(ctx context.Context, id string, perm *Permission) (*Response, error) {
 	if id == "" {
-		return errors.New("id is required")
+		return nil, errors.New("id is required")
 	}
 
 	uri := path.Join("permissions", id)
-	return p.client.makeRequest(ctx, http.MethodPut, uri, nil, perm, nil)
+
+	var resp Response
+	err := p.client.makeRequest(ctx, http.MethodPut, uri, nil, perm, &resp)
+	return &resp, err
+}
+
+type ListPermissionsResponse struct {
+	Permissions []*Permission `json:"permissions"`
+	Response
 }
 
 // ListPermissions returns all permissions of an app.
-func (p *PermissionClient) ListPermissions(ctx context.Context) ([]*Permission, error) {
-	var perm listPermissionsResponse
+func (p *PermissionClient) ListPermissions(ctx context.Context) (*ListPermissionsResponse, error) {
+	var perm ListPermissionsResponse
 	err := p.client.makeRequest(ctx, http.MethodGet, "permissions", nil, nil, &perm)
-	return perm.Permissions, err
+	return &perm, err
 }
 
 // DeletePermission deletes a permission by id.
-func (p *PermissionClient) DeletePermission(ctx context.Context, id string) error {
+func (p *PermissionClient) DeletePermission(ctx context.Context, id string) (*Response, error) {
 	if id == "" {
-		return errors.New("id is required")
+		return nil, errors.New("id is required")
 	}
 
 	uri := path.Join("permissions", id)
-	return p.client.makeRequest(ctx, http.MethodDelete, uri, nil, nil, nil)
+
+	var resp Response
+	err := p.client.makeRequest(ctx, http.MethodDelete, uri, nil, nil, &resp)
+	return &resp, err
 }

--- a/query_test.go
+++ b/query_test.go
@@ -267,10 +267,10 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 	msg2 := resp.Message
 
 	// flag 2 messages
-	err = c.FlagMessage(context.Background(), msg2.ID, user1.ID)
+	_, err = c.FlagMessage(context.Background(), msg2.ID, user1.ID)
 	require.NoError(t, err)
 
-	err = c.FlagMessage(context.Background(), msg1.ID, user2.ID)
+	_, err = c.FlagMessage(context.Background(), msg1.ID, user2.ID)
 	require.NoError(t, err)
 
 	// both flags show up in this query by channel_cid
@@ -294,9 +294,9 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 	assert.Len(t, got, 1)
 
 	// unflag these 2 messages
-	err = c.UnflagMessage(context.Background(), msg1.ID, user2.ID)
+	_, err = c.UnflagMessage(context.Background(), msg1.ID, user2.ID)
 	require.NoError(t, err)
-	err = c.UnflagMessage(context.Background(), msg2.ID, user1.ID)
+	_, err = c.UnflagMessage(context.Background(), msg2.ID, user1.ID)
 	require.NoError(t, err)
 
 	// none should show up

--- a/query_test.go
+++ b/query_test.go
@@ -42,7 +42,7 @@ func TestClient_QueryUsers(t *testing.T) {
 		})
 
 		require.NoError(tt, err)
-		require.Len(tt, results, len(ids))
+		require.Len(tt, results.Users, len(ids))
 	})
 
 	t.Run("Query with offset/limit", func(tt *testing.T) {
@@ -61,10 +61,10 @@ func TestClient_QueryUsers(t *testing.T) {
 		)
 
 		require.NoError(tt, err)
-		require.Len(tt, results, 2)
+		require.Len(tt, results.Users, 2)
 
-		require.Equal(tt, results[0].ID, ids[offset])
-		require.Equal(tt, results[1].ID, ids[offset+1])
+		require.Equal(tt, results.Users[0].ID, ids[offset])
+		require.Equal(tt, results.Users[1].ID, ids[offset+1])
 	})
 }
 
@@ -78,7 +78,7 @@ func TestClient_QueryChannels(t *testing.T) {
 	require.NoError(t, err)
 
 	messageLimit := 1
-	got, err := c.QueryChannels(context.Background(), &QueryOption{
+	resp, err := c.QueryChannels(context.Background(), &QueryOption{
 		Filter: map[string]interface{}{
 			"id": map[string]interface{}{
 				"$eq": ch.ID,
@@ -88,8 +88,8 @@ func TestClient_QueryChannels(t *testing.T) {
 	})
 
 	require.NoError(t, err, "query channels error")
-	require.Equal(t, ch.ID, got[0].ID, "received channel ID")
-	require.Len(t, got[0].Messages, messageLimit)
+	require.Equal(t, ch.ID, resp.Channels[0].ID, "received channel ID")
+	require.Len(t, resp.Channels[0].Messages, messageLimit)
 }
 
 func TestClient_Search(t *testing.T) {
@@ -108,7 +108,7 @@ func TestClient_Search(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Query", func(tt *testing.T) {
-		got, err := c.Search(context.Background(), SearchRequest{Query: text, Filters: map[string]interface{}{
+		resp, err := c.Search(context.Background(), SearchRequest{Query: text, Filters: map[string]interface{}{
 			"members": map[string][]string{
 				"$in": {user1.ID, user2.ID},
 			},
@@ -116,10 +116,10 @@ func TestClient_Search(t *testing.T) {
 
 		require.NoError(tt, err)
 
-		assert.Len(tt, got, 2)
+		assert.Len(tt, resp.Messages, 2)
 	})
 	t.Run("Message filters", func(tt *testing.T) {
-		got, err := c.Search(context.Background(), SearchRequest{
+		resp, err := c.Search(context.Background(), SearchRequest{
 			Filters: map[string]interface{}{
 				"members": map[string][]string{
 					"$in": {user1.ID, user2.ID},
@@ -133,7 +133,7 @@ func TestClient_Search(t *testing.T) {
 		})
 		require.NoError(tt, err)
 
-		assert.Len(tt, got, 2)
+		assert.Len(tt, resp.Messages, 2)
 	})
 	t.Run("Query and message filters error", func(tt *testing.T) {
 		_, err := c.Search(context.Background(), SearchRequest{
@@ -282,7 +282,7 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Len(t, got, 2)
+	assert.Len(t, got.Flags, 2)
 
 	// one flag shows up in this query by user_id
 	got, err = c.QueryMessageFlags(context.Background(), &QueryOption{
@@ -291,7 +291,7 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Len(t, got, 1)
+	assert.Len(t, got.Flags, 1)
 
 	// unflag these 2 messages
 	_, err = c.UnflagMessage(context.Background(), msg1.ID, user2.ID)
@@ -304,5 +304,5 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 		Filter: map[string]interface{}{"channel_cid": ch.cid()},
 	})
 	require.NoError(t, err)
-	assert.Len(t, got, 0)
+	assert.Len(t, got.Flags, 0)
 }

--- a/query_test.go
+++ b/query_test.go
@@ -258,10 +258,13 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 
 	// send 2 messages
 	text := randomString(10)
-	msg1, err := ch.SendMessage(context.Background(), &Message{Text: text + " " + randomString(25)}, user1.ID)
+	resp, err := ch.SendMessage(context.Background(), &Message{Text: text + " " + randomString(25)}, user1.ID)
 	require.NoError(t, err)
-	msg2, err := ch.SendMessage(context.Background(), &Message{Text: text + " " + randomString(25)}, user2.ID)
+	msg1 := resp.Message
+
+	resp, err = ch.SendMessage(context.Background(), &Message{Text: text + " " + randomString(25)}, user2.ID)
 	require.NoError(t, err)
+	msg2 := resp.Message
 
 	// flag 2 messages
 	err = c.FlagMessage(context.Background(), msg2.ID, user1.ID)

--- a/query_test.go
+++ b/query_test.go
@@ -18,7 +18,7 @@ func TestClient_QueryUsers(t *testing.T) {
 	defer func() {
 		for _, id := range ids {
 			if id != "" {
-				_ = c.DeleteUser(context.Background(), id, nil)
+				_, _ = c.DeleteUser(context.Background(), id, nil)
 			}
 		}
 	}()

--- a/rate_limits.go
+++ b/rate_limits.go
@@ -30,11 +30,11 @@ func NewRateLimitFromHeaders(headers http.Header) *RateLimitInfo {
 
 	limit, err := strconv.ParseInt(headers.Get(HeaderRateLimit), 10, 64)
 	if err == nil {
-		rl.Limit = int64(limit)
+		rl.Limit = limit
 	}
 	remaining, err := strconv.ParseInt(headers.Get(HeaderRateRemaining), 10, 64)
 	if err == nil {
-		rl.Remaining = int64(remaining)
+		rl.Remaining = remaining
 	}
 	reset, err := strconv.ParseInt(headers.Get(HeaderRateReset), 10, 64)
 	if err == nil && reset > 0 {

--- a/rate_limits.go
+++ b/rate_limits.go
@@ -4,8 +4,15 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
+)
+
+const (
+	HeaderRateLimit     = "X-Ratelimit-Limit"
+	HeaderRateRemaining = "X-Ratelimit-Remaining"
+	HeaderRateReset     = "X-Ratelimit-Reset"
 )
 
 // RateLimitInfo represents the quota and usage for a single endpoint.
@@ -16,6 +23,25 @@ type RateLimitInfo struct {
 	Remaining int64 `json:"remaining"`
 	// Reset is the Unix timestamp of the expiration of the current rate limit time window.
 	Reset int64 `json:"reset"`
+}
+
+func NewRateLimitFromHeaders(headers http.Header) *RateLimitInfo {
+	var rl RateLimitInfo
+
+	limit, err := strconv.ParseInt(headers.Get(HeaderRateLimit), 10, 64)
+	if err == nil {
+		rl.Limit = int64(limit)
+	}
+	remaining, err := strconv.ParseInt(headers.Get(HeaderRateRemaining), 10, 64)
+	if err == nil {
+		rl.Remaining = int64(remaining)
+	}
+	reset, err := strconv.ParseInt(headers.Get(HeaderRateReset), 10, 64)
+	if err == nil && reset > 0 {
+		rl.Reset = reset
+	}
+
+	return &rl
 }
 
 // RateLimitsMap holds the rate limit information, where the keys are the names of the endpoints and the values are

--- a/reaction_test.go
+++ b/reaction_test.go
@@ -41,12 +41,12 @@ func TestChannel_SendReaction(t *testing.T) {
 	require.NoError(t, err, "send message")
 
 	reaction := Reaction{Type: "love"}
-	msg, err = ch.SendReaction(context.Background(), &reaction, resp.Message.ID, user.ID)
+	reactionResp, err := ch.SendReaction(context.Background(), &reaction, resp.Message.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
-	assert.Equal(t, 1, msg.ReactionCounts[reaction.Type], "reaction count", reaction)
+	assert.Equal(t, 1, reactionResp.Message.ReactionCounts[reaction.Type], "reaction count", reaction)
 
-	assert.Condition(t, reactionExistsCondition(msg.LatestReactions, reaction.Type), "latest reaction exists")
+	assert.Condition(t, reactionExistsCondition(reactionResp.Message.LatestReactions, reaction.Type), "latest reaction exists")
 }
 
 func reactionExistsCondition(reactions []*Reaction, searchType string) func() bool {
@@ -77,14 +77,14 @@ func TestChannel_DeleteReaction(t *testing.T) {
 	require.NoError(t, err, "send message")
 
 	reaction := Reaction{Type: "love"}
-	msg, err = ch.SendReaction(context.Background(), &reaction, resp.Message.ID, user.ID)
+	reactionResp, err := ch.SendReaction(context.Background(), &reaction, resp.Message.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
-	msg, err = ch.DeleteReaction(context.Background(), msg.ID, reaction.Type, user.ID)
+	reactionResp, err = ch.DeleteReaction(context.Background(), reactionResp.Message.ID, reaction.Type, user.ID)
 	require.NoError(t, err, "delete reaction")
 
-	assert.Equal(t, 0, msg.ReactionCounts[reaction.Type], "reaction count")
-	assert.Empty(t, msg.LatestReactions, "latest reactions empty")
+	assert.Equal(t, 0, reactionResp.Message.ReactionCounts[reaction.Type], "reaction count")
+	assert.Empty(t, reactionResp.Message.LatestReactions, "latest reactions empty")
 }
 
 func TestChannel_GetReactions(t *testing.T) {
@@ -110,11 +110,11 @@ func TestChannel_GetReactions(t *testing.T) {
 
 	reaction := Reaction{Type: "love"}
 
-	msg, err = ch.SendReaction(context.Background(), &reaction, msg.ID, user.ID)
+	reactionResp, err := ch.SendReaction(context.Background(), &reaction, msg.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
-	reactions, err = ch.GetReactions(context.Background(), msg.ID, nil)
+	reactionsResp, err := ch.GetReactions(context.Background(), reactionResp.Message.ID, nil)
 	require.NoError(t, err, "get reactions")
 
-	assert.Condition(t, reactionExistsCondition(reactions, reaction.Type), "reaction exists")
+	assert.Condition(t, reactionExistsCondition(reactionsResp.Reactions, reaction.Type), "reaction exists")
 }

--- a/reaction_test.go
+++ b/reaction_test.go
@@ -104,16 +104,16 @@ func TestChannel_GetReactions(t *testing.T) {
 	require.NoError(t, err, "send message")
 	msg = resp.Message
 
-	reactions, err := ch.GetReactions(context.Background(), msg.ID, nil)
+	reactionsResp, err := ch.GetReactions(context.Background(), msg.ID, nil)
 	require.NoError(t, err, "get reactions")
-	assert.Empty(t, reactions, "reactions empty")
+	assert.Empty(t, reactionsResp.Reactions, "reactions empty")
 
 	reaction := Reaction{Type: "love"}
 
 	reactionResp, err := ch.SendReaction(context.Background(), &reaction, msg.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
-	reactionsResp, err := ch.GetReactions(context.Background(), reactionResp.Message.ID, nil)
+	reactionsResp, err = ch.GetReactions(context.Background(), reactionResp.Message.ID, nil)
 	require.NoError(t, err, "get reactions")
 
 	assert.Condition(t, reactionExistsCondition(reactionsResp.Reactions, reaction.Type), "reaction exists")

--- a/reaction_test.go
+++ b/reaction_test.go
@@ -36,12 +36,11 @@ func TestChannel_SendReaction(t *testing.T) {
 		Text: "test message",
 		User: user,
 	}
-	msg, err := ch.SendMessage(context.Background(), msg, user.ID)
+	resp, err := ch.SendMessage(context.Background(), msg, user.ID)
 	require.NoError(t, err, "send message")
 
 	reaction := Reaction{Type: "love"}
-
-	msg, err = ch.SendReaction(context.Background(), &reaction, msg.ID, user.ID)
+	msg, err = ch.SendReaction(context.Background(), &reaction, resp.Message.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
 	assert.Equal(t, 1, msg.ReactionCounts[reaction.Type], "reaction count", reaction)
@@ -72,12 +71,11 @@ func TestChannel_DeleteReaction(t *testing.T) {
 		Text: "test message",
 		User: user,
 	}
-	msg, err := ch.SendMessage(context.Background(), msg, user.ID)
+	resp, err := ch.SendMessage(context.Background(), msg, user.ID)
 	require.NoError(t, err, "send message")
 
 	reaction := Reaction{Type: "love"}
-
-	msg, err = ch.SendReaction(context.Background(), &reaction, msg.ID, user.ID)
+	msg, err = ch.SendReaction(context.Background(), &reaction, resp.Message.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
 	msg, err = ch.DeleteReaction(context.Background(), msg.ID, reaction.Type, user.ID)
@@ -99,8 +97,9 @@ func TestChannel_GetReactions(t *testing.T) {
 		Text: "test message",
 		User: user,
 	}
-	msg, err := ch.SendMessage(context.Background(), msg, user.ID)
+	resp, err := ch.SendMessage(context.Background(), msg, user.ID)
 	require.NoError(t, err, "send message")
+	msg = resp.Message
 
 	reactions, err := ch.GetReactions(context.Background(), msg.ID, nil)
 	require.NoError(t, err, "get reactions")

--- a/reaction_test.go
+++ b/reaction_test.go
@@ -28,7 +28,8 @@ func TestChannel_SendReaction(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		require.NoError(t, ch.Delete(context.Background()), "delete channel")
+		_, err := ch.Delete(context.Background())
+		require.NoError(t, err, "delete channel")
 	}()
 
 	user := randomUser(t, c)
@@ -63,7 +64,8 @@ func TestChannel_DeleteReaction(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		require.NoError(t, ch.Delete(context.Background()), "delete channel")
+		_, err := ch.Delete(context.Background())
+		require.NoError(t, err, "delete channel")
 	}()
 
 	user := randomUser(t, c)
@@ -89,7 +91,8 @@ func TestChannel_GetReactions(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
 	defer func() {
-		require.NoError(t, ch.Delete(context.Background()), "delete channel")
+		_, err := ch.Delete(context.Background())
+		require.NoError(t, err, "delete channel")
 	}()
 
 	user := randomUser(t, c)

--- a/user.go
+++ b/user.go
@@ -29,10 +29,6 @@ type ChannelMute struct {
 	UpdatedAt time.Time  `json:"updated_at"`
 }
 
-type ChannelMuteResponse struct {
-	ChannelMute ChannelMute `json:"channel_mute"`
-}
-
 type User struct {
 	ID    string   `json:"id"`
 	Name  string   `json:"name,omitempty"`
@@ -178,12 +174,12 @@ func (c *Client) UnFlagUser(ctx context.Context, targetID string, options map[st
 	return c.makeRequest(ctx, http.MethodPost, "moderation/unflag", nil, options, nil)
 }
 
-func (c *Client) BanUser(ctx context.Context, targetID, userID string, options map[string]interface{}) error {
+func (c *Client) BanUser(ctx context.Context, targetID, userID string, options map[string]interface{}) (*Response, error) {
 	switch {
 	case targetID == "":
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	case userID == "":
-		return errors.New("user ID is empty")
+		return nil, errors.New("user ID is empty")
 	case options == nil:
 		options = map[string]interface{}{}
 	}
@@ -191,13 +187,15 @@ func (c *Client) BanUser(ctx context.Context, targetID, userID string, options m
 	options["target_user_id"] = targetID
 	options["user_id"] = userID
 
-	return c.makeRequest(ctx, http.MethodPost, "moderation/ban", nil, options, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, "moderation/ban", nil, options, &resp)
+	return &resp, err
 }
 
-func (c *Client) UnBanUser(ctx context.Context, targetID string, options map[string]string) error {
+func (c *Client) UnBanUser(ctx context.Context, targetID string, options map[string]string) (*Response, error) {
 	switch {
 	case targetID == "":
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	case options == nil:
 		options = map[string]string{}
 	}
@@ -209,13 +207,15 @@ func (c *Client) UnBanUser(ctx context.Context, targetID string, options map[str
 	}
 	params.Set("target_user_id", targetID)
 
-	return c.makeRequest(ctx, http.MethodDelete, "moderation/ban", params, nil, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodDelete, "moderation/ban", params, nil, &resp)
+	return &resp, err
 }
 
 // ShadowBan shadow bans userID
 // bannedByID: user who shadow bans userID.
 // options: additional shadow ban options, ie {"timeout": 3600, "reason": "offensive language is not allowed here"}.
-func (c *Client) ShadowBan(ctx context.Context, userID, bannedByID string, options map[string]interface{}) error {
+func (c *Client) ShadowBan(ctx context.Context, userID, bannedByID string, options map[string]interface{}) (*Response, error) {
 	if options == nil {
 		options = map[string]interface{}{}
 	}
@@ -224,7 +224,7 @@ func (c *Client) ShadowBan(ctx context.Context, userID, bannedByID string, optio
 }
 
 // RemoveShadowBan removes the ban for userID.
-func (c *Client) RemoveShadowBan(ctx context.Context, userID string, options map[string]string) error {
+func (c *Client) RemoveShadowBan(ctx context.Context, userID string, options map[string]string) (*Response, error) {
 	if options == nil {
 		options = map[string]string{}
 	}

--- a/user.go
+++ b/user.go
@@ -75,12 +75,12 @@ func (u User) MarshalJSON() ([]byte, error) {
 // MuteUser creates a mute.
 // targetID: the user getting muted.
 // userID: the user is muting the target.
-func (c *Client) MuteUser(ctx context.Context, targetID, userID string, options map[string]interface{}) error {
+func (c *Client) MuteUser(ctx context.Context, targetID, userID string, options map[string]interface{}) (*Response, error) {
 	switch {
 	case targetID == "":
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	case userID == "":
-		return errors.New("user ID is empty")
+		return nil, errors.New("user ID is empty")
 	case options == nil:
 		options = map[string]interface{}{}
 	}
@@ -88,18 +88,20 @@ func (c *Client) MuteUser(ctx context.Context, targetID, userID string, options 
 	options["target_id"] = targetID
 	options["user_id"] = userID
 
-	return c.makeRequest(ctx, http.MethodPost, "moderation/mute", nil, options, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, "moderation/mute", nil, options, &resp)
+	return &resp, err
 }
 
 // MuteUsers creates mutes for multiple users.
 // targetIDs: the users getting muted.
 // userID: the user is muting the target.
-func (c *Client) MuteUsers(ctx context.Context, targetIDs []string, userID string, options map[string]interface{}) error {
+func (c *Client) MuteUsers(ctx context.Context, targetIDs []string, userID string, options map[string]interface{}) (*Response, error) {
 	switch {
 	case len(targetIDs) == 0:
-		return errors.New("target IDs are empty")
+		return nil, errors.New("target IDs are empty")
 	case userID == "":
-		return errors.New("user ID is empty")
+		return nil, errors.New("user ID is empty")
 	case options == nil:
 		options = map[string]interface{}{}
 	}
@@ -107,18 +109,20 @@ func (c *Client) MuteUsers(ctx context.Context, targetIDs []string, userID strin
 	options["target_ids"] = targetIDs
 	options["user_id"] = userID
 
-	return c.makeRequest(ctx, http.MethodPost, "moderation/mute", nil, options, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, "moderation/mute", nil, options, &resp)
+	return &resp, err
 }
 
 // UnmuteUser removes a mute.
 // targetID: the user is getting un-muted.
 // userID: the user is muting the target.
-func (c *Client) UnmuteUser(ctx context.Context, targetID, userID string) error {
+func (c *Client) UnmuteUser(ctx context.Context, targetID, userID string) (*Response, error) {
 	switch {
 	case targetID == "":
-		return errors.New("target IDs is empty")
+		return nil, errors.New("target IDs is empty")
 	case userID == "":
-		return errors.New("user ID is empty")
+		return nil, errors.New("user ID is empty")
 	}
 
 	data := map[string]interface{}{
@@ -126,18 +130,20 @@ func (c *Client) UnmuteUser(ctx context.Context, targetID, userID string) error 
 		"user_id":   userID,
 	}
 
-	return c.makeRequest(ctx, http.MethodPost, "moderation/unmute", nil, data, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, "moderation/unmute", nil, data, &resp)
+	return &resp, err
 }
 
 // UnmuteUsers removes a mute.
 // targetID: the users are getting un-muted.
 // userID: the user is muting the target.
-func (c *Client) UnmuteUsers(ctx context.Context, targetIDs []string, userID string) error {
+func (c *Client) UnmuteUsers(ctx context.Context, targetIDs []string, userID string) (*Response, error) {
 	switch {
 	case len(targetIDs) == 0:
-		return errors.New("target IDs is empty")
+		return nil, errors.New("target IDs is empty")
 	case userID == "":
-		return errors.New("user ID is empty")
+		return nil, errors.New("user ID is empty")
 	}
 
 	data := map[string]interface{}{
@@ -145,33 +151,39 @@ func (c *Client) UnmuteUsers(ctx context.Context, targetIDs []string, userID str
 		"user_id":    userID,
 	}
 
-	return c.makeRequest(ctx, http.MethodPost, "moderation/unmute", nil, data, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, "moderation/unmute", nil, data, &resp)
+	return &resp, err
 }
 
-func (c *Client) FlagUser(ctx context.Context, targetID string, options map[string]interface{}) error {
+func (c *Client) FlagUser(ctx context.Context, targetID string, options map[string]interface{}) (*Response, error) {
 	switch {
 	case targetID == "":
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	case len(options) == 0:
-		return errors.New("flag user: options must be not empty")
+		return nil, errors.New("flag user: options must be not empty")
 	}
 
 	options["target_user_id"] = targetID
 
-	return c.makeRequest(ctx, http.MethodPost, "moderation/flag", nil, options, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, "moderation/flag", nil, options, &resp)
+	return &resp, err
 }
 
-func (c *Client) UnFlagUser(ctx context.Context, targetID string, options map[string]interface{}) error {
+func (c *Client) UnFlagUser(ctx context.Context, targetID string, options map[string]interface{}) (*Response, error) {
 	switch {
 	case targetID == "":
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	case options == nil:
 		options = map[string]interface{}{}
 	}
 
 	options["target_user_id"] = targetID
 
-	return c.makeRequest(ctx, http.MethodPost, "moderation/unflag", nil, options, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, "moderation/unflag", nil, options, &resp)
+	return &resp, err
 }
 
 func (c *Client) BanUser(ctx context.Context, targetID, userID string, options map[string]interface{}) (*Response, error) {
@@ -232,50 +244,57 @@ func (c *Client) RemoveShadowBan(ctx context.Context, userID string, options map
 	return c.UnBanUser(ctx, userID, options)
 }
 
-func (c *Client) ExportUser(ctx context.Context, targetID string, options map[string][]string) (user *User, err error) {
+type ExportUserResponse struct {
+	*User
+	Response
+}
+
+func (c *Client) ExportUser(ctx context.Context, targetID string, options map[string][]string) (*ExportUserResponse, error) {
 	if targetID == "" {
-		return user, errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	}
 
 	p := path.Join("users", url.PathEscape(targetID), "export")
-	user = &User{}
 
-	err = c.makeRequest(ctx, http.MethodGet, p, options, nil, user)
-	return user, err
+	var resp ExportUserResponse
+	err := c.makeRequest(ctx, http.MethodGet, p, options, nil, &resp)
+	return &resp, err
 }
 
-func (c *Client) DeactivateUser(ctx context.Context, targetID string, options map[string]interface{}) error {
+func (c *Client) DeactivateUser(ctx context.Context, targetID string, options map[string]interface{}) (*Response, error) {
 	if targetID == "" {
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	}
 
 	p := path.Join("users", url.PathEscape(targetID), "deactivate")
 
-	return c.makeRequest(ctx, http.MethodPost, p, nil, options, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, p, nil, options, &resp)
+	return &resp, err
 }
 
-func (c *Client) ReactivateUser(ctx context.Context, targetID string, options map[string]interface{}) error {
+func (c *Client) ReactivateUser(ctx context.Context, targetID string, options map[string]interface{}) (*Response, error) {
 	if targetID == "" {
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	}
 
 	p := path.Join("users", url.PathEscape(targetID), "reactivate")
 
-	return c.makeRequest(ctx, http.MethodPost, p, nil, options, nil)
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, p, nil, options, &resp)
+	return &resp, err
 }
 
-func (c *Client) DeleteUser(ctx context.Context, targetID string, options map[string][]string) error {
+func (c *Client) DeleteUser(ctx context.Context, targetID string, options map[string][]string) (*Response, error) {
 	if targetID == "" {
-		return errors.New("target ID is empty")
+		return nil, errors.New("target ID is empty")
 	}
 
 	p := path.Join("users", url.PathEscape(targetID))
 
-	return c.makeRequest(ctx, http.MethodDelete, p, options, nil, nil)
-}
-
-type usersResponse struct {
-	Users map[string]*User `json:"users"`
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodDelete, p, options, nil, &resp)
+	return &resp, err
 }
 
 type usersRequest struct {
@@ -291,22 +310,35 @@ type userRequest struct {
 	LastActive time.Time `json:"-"`
 }
 
+type UpsertUserResponse struct {
+	User *User
+	Response
+}
+
 // UpsertUser is a single user version of UpsertUsers for convenience.
-func (c *Client) UpsertUser(ctx context.Context, user *User) (*User, error) {
-	users, err := c.UpsertUsers(ctx, user)
-	return users[user.ID], err
+func (c *Client) UpsertUser(ctx context.Context, user *User) (*UpsertUserResponse, error) {
+	resp, err := c.UpsertUsers(ctx, user)
+	return &UpsertUserResponse{
+		User:     resp.Users[user.ID],
+		Response: resp.Response,
+	}, err
 }
 
 // UpdateUser sending update users request, returns updated user info.
 //
 // Deprecated: Use UpsertUser. Renamed for clarification, functionality remains the same.
-func (c *Client) UpdateUser(ctx context.Context, user *User) (*User, error) {
+func (c *Client) UpdateUser(ctx context.Context, user *User) (*UpsertUserResponse, error) {
 	return c.UpsertUser(ctx, user)
+}
+
+type UsersResponse struct {
+	Users map[string]*User `json:"users"`
+	Response
 }
 
 // UpsertUsers creates the given users. If a user doesn't exist, it will be created.
 // Otherwise, custom data will be extended or updated. Missing data is never removed.
-func (c *Client) UpsertUsers(ctx context.Context, users ...*User) (map[string]*User, error) {
+func (c *Client) UpsertUsers(ctx context.Context, users ...*User) (*UsersResponse, error) {
 	if len(users) == 0 {
 		return nil, errors.New("users are not set")
 	}
@@ -316,16 +348,15 @@ func (c *Client) UpsertUsers(ctx context.Context, users ...*User) (map[string]*U
 		req.Users[u.ID] = userRequest{User: u}
 	}
 
-	var resp usersResponse
-
+	var resp UsersResponse
 	err := c.makeRequest(ctx, http.MethodPost, "users", nil, req, &resp)
-	return resp.Users, err
+	return &resp, err
 }
 
 // UpdateUsers sends update user request, returns updated user info.
 //
 // Deprecated: Use UpsertUsers. Renamed for clarification, functionality remains the same.
-func (c *Client) UpdateUsers(ctx context.Context, users ...*User) (map[string]*User, error) {
+func (c *Client) UpdateUsers(ctx context.Context, users ...*User) (*UsersResponse, error) {
 	return c.UpsertUsers(ctx, users...)
 }
 
@@ -340,12 +371,12 @@ type PartialUserUpdate struct {
 
 // PartialUpdateUser makes partial update for single user.
 func (c *Client) PartialUpdateUser(ctx context.Context, update PartialUserUpdate) (*User, error) {
-	res, err := c.PartialUpdateUsers(ctx, []PartialUserUpdate{update})
+	resp, err := c.PartialUpdateUsers(ctx, []PartialUserUpdate{update})
 	if err != nil {
 		return nil, err
 	}
 
-	if user, ok := res[update.ID]; ok {
+	if user, ok := resp.Users[update.ID]; ok {
 		return user, nil
 	}
 
@@ -357,20 +388,20 @@ type partialUserUpdateReq struct {
 }
 
 // PartialUpdateUsers makes partial update for users.
-func (c *Client) PartialUpdateUsers(ctx context.Context, updates []PartialUserUpdate) (map[string]*User, error) {
-	var resp usersResponse
+func (c *Client) PartialUpdateUsers(ctx context.Context, updates []PartialUserUpdate) (*UsersResponse, error) {
+	var resp UsersResponse
 
 	err := c.makeRequest(ctx, http.MethodPatch, "users", nil, partialUserUpdateReq{Users: updates}, &resp)
-	return resp.Users, err
+	return &resp, err
 }
 
 // RevokeUserToken revoke token for a user issued before given time.
-func (c *Client) RevokeUserToken(ctx context.Context, userID string, before *time.Time) error {
+func (c *Client) RevokeUserToken(ctx context.Context, userID string, before *time.Time) (*Response, error) {
 	return c.RevokeUsersTokens(ctx, []string{userID}, before)
 }
 
 // RevokeUsersTokens revoke tokens for users issued before given time.
-func (c *Client) RevokeUsersTokens(ctx context.Context, userIDs []string, before *time.Time) error {
+func (c *Client) RevokeUsersTokens(ctx context.Context, userIDs []string, before *time.Time) (*Response, error) {
 	userUpdates := make([]PartialUserUpdate, 0)
 	for _, userID := range userIDs {
 		userUpdate := PartialUserUpdate{
@@ -385,6 +416,6 @@ func (c *Client) RevokeUsersTokens(ctx context.Context, userIDs []string, before
 		userUpdates = append(userUpdates, userUpdate)
 	}
 
-	_, err := c.PartialUpdateUsers(ctx, userUpdates)
-	return err
+	resp, err := c.PartialUpdateUsers(ctx, userUpdates)
+	return &resp.Response, err
 }

--- a/user_test.go
+++ b/user_test.go
@@ -98,7 +98,7 @@ func TestClient_MuteUser(t *testing.T) {
 	c := initClient(t)
 
 	user := randomUser(t, c)
-	err := c.MuteUser(context.Background(), randomUser(t, c).ID, user.ID, nil)
+	_, err := c.MuteUser(context.Background(), randomUser(t, c).ID, user.ID, nil)
 	require.NoError(t, err, "MuteUser should not return an error")
 
 	resp, err := c.QueryUsers(context.Background(), &QueryOption{
@@ -119,7 +119,7 @@ func TestClient_MuteUser(t *testing.T) {
 
 	user = randomUser(t, c)
 	// when timeout is given, expiration field should be set on mute
-	err = c.MuteUser(context.Background(), randomUser(t, c).ID, user.ID, map[string]interface{}{"timeout": 60})
+	_, err = c.MuteUser(context.Background(), randomUser(t, c).ID, user.ID, map[string]interface{}{"timeout": 60})
 	require.NoError(t, err, "MuteUser should not return an error")
 
 	resp, err = c.QueryUsers(context.Background(), &QueryOption{
@@ -145,7 +145,7 @@ func TestClient_MuteUsers(t *testing.T) {
 	user := randomUser(t, c)
 	targetIDs := randomUsersID(t, c, 2)
 
-	err := c.MuteUsers(context.Background(), targetIDs, user.ID, map[string]interface{}{"timeout": 60})
+	_, err := c.MuteUsers(context.Background(), targetIDs, user.ID, map[string]interface{}{"timeout": 60})
 	require.NoError(t, err, "MuteUsers should not return an error")
 
 	resp, err := c.QueryUsers(context.Background(), &QueryOption{
@@ -175,10 +175,10 @@ func TestClient_UnmuteUser(t *testing.T) {
 
 	user := randomUser(t, c)
 	mutedUser := randomUser(t, c)
-	err := c.MuteUser(context.Background(), mutedUser.ID, user.ID, nil)
+	_, err := c.MuteUser(context.Background(), mutedUser.ID, user.ID, nil)
 	require.NoError(t, err, "MuteUser should not return an error")
 
-	err = c.UnmuteUser(context.Background(), mutedUser.ID, user.ID)
+	_, err = c.UnmuteUser(context.Background(), mutedUser.ID, user.ID)
 	assert.NoError(t, err)
 }
 
@@ -187,10 +187,10 @@ func TestClient_UnmuteUsers(t *testing.T) {
 
 	user := randomUser(t, c)
 	targetIDs := []string{randomUser(t, c).ID, randomUser(t, c).ID}
-	err := c.MuteUsers(context.Background(), targetIDs, user.ID, nil)
+	_, err := c.MuteUsers(context.Background(), targetIDs, user.ID, nil)
 	require.NoError(t, err, "MuteUsers should not return an error")
 
-	err = c.UnmuteUsers(context.Background(), targetIDs, user.ID)
+	_, err = c.UnmuteUsers(context.Background(), targetIDs, user.ID)
 	assert.NoError(t, err, "unmute users")
 }
 
@@ -202,9 +202,9 @@ func TestClient_UpsertUsers(t *testing.T) {
 	resp, err := c.UpsertUsers(context.Background(), user)
 	require.NoError(t, err, "update users")
 
-	assert.Contains(t, resp, user.ID)
-	assert.NotEmpty(t, resp[user.ID].CreatedAt)
-	assert.NotEmpty(t, resp[user.ID].UpdatedAt)
+	assert.Contains(t, resp.Users, user.ID)
+	assert.NotEmpty(t, resp.Users[user.ID].CreatedAt)
+	assert.NotEmpty(t, resp.Users[user.ID].UpdatedAt)
 }
 
 func TestClient_PartialUpdateUsers(t *testing.T) {
@@ -221,9 +221,10 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 		},
 	}
 
-	got, err := c.PartialUpdateUsers(context.Background(), []PartialUserUpdate{update})
+	resp, err := c.PartialUpdateUsers(context.Background(), []PartialUserUpdate{update})
 	require.NoError(t, err, "partial update user")
 
+	got := resp.Users
 	assert.Contains(t, got, user.ID)
 	assert.Contains(t, got[user.ID].ExtraData, "test",
 		"extra data contains: %v", got[user.ID].ExtraData)
@@ -236,9 +237,10 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 		Unset: []string{"test.passed"},
 	}
 
-	got, err = c.PartialUpdateUsers(context.Background(), []PartialUserUpdate{update})
+	resp, err = c.PartialUpdateUsers(context.Background(), []PartialUserUpdate{update})
 	require.NoError(t, err, "partial update user")
 
+	got = resp.Users
 	assert.Contains(t, got, user.ID)
 	assert.Contains(t, got[user.ID].ExtraData, "test", "extra data contains", got[user.ID].ExtraData)
 	assert.Empty(t, got[user.ID].ExtraData["test"], "extra data field removed")
@@ -267,19 +269,19 @@ func ExampleClient_ExportUser() {
 func ExampleClient_DeactivateUser() {
 	client, _ := NewClient("XXXX", "XXXX")
 
-	_ = client.DeactivateUser(context.Background(), "userID", nil)
+	_, _ = client.DeactivateUser(context.Background(), "userID", nil)
 }
 
 func ExampleClient_ReactivateUser() {
 	client, _ := NewClient("XXXX", "XXXX")
 
-	_ = client.ReactivateUser(context.Background(), "userID", nil)
+	_, _ = client.ReactivateUser(context.Background(), "userID", nil)
 }
 
 func ExampleClient_DeleteUser() {
 	client, _ := NewClient("XXXX", "XXXX")
 
-	_ = client.DeleteUser(context.Background(), "userID", nil)
+	_, _ = client.DeleteUser(context.Background(), "userID", nil)
 }
 
 func ExampleClient_DeleteUser_hard() {
@@ -290,7 +292,7 @@ func ExampleClient_DeleteUser_hard() {
 		"hard_delete":           {"true"},
 	}
 
-	_ = client.DeleteUser(context.Background(), "userID", options)
+	_, _ = client.DeleteUser(context.Background(), "userID", options)
 }
 
 func ExampleClient_BanUser() {

--- a/user_test.go
+++ b/user_test.go
@@ -28,8 +28,10 @@ func TestClient_ShadowBanUser(t *testing.T) {
 	require.NoError(t, err)
 
 	msg := &Message{Text: "test message"}
-	msg, err = ch.SendMessage(context.Background(), msg, userB.ID)
+	resp, err := ch.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
+
+	msg = resp.Message
 	require.Equal(t, false, msg.Shadowed)
 
 	msg, err = c.GetMessage(context.Background(), msg.ID)
@@ -37,8 +39,10 @@ func TestClient_ShadowBanUser(t *testing.T) {
 	require.Equal(t, true, msg.Shadowed)
 
 	msg = &Message{Text: "test message"}
-	msg, err = ch.SendMessage(context.Background(), msg, userC.ID)
+	resp, err = ch.SendMessage(context.Background(), msg, userC.ID)
 	require.NoError(t, err)
+
+	msg = resp.Message
 	require.Equal(t, false, msg.Shadowed)
 
 	msg, err = c.GetMessage(context.Background(), msg.ID)
@@ -49,8 +53,10 @@ func TestClient_ShadowBanUser(t *testing.T) {
 	require.NoError(t, err)
 
 	msg = &Message{Text: "test message"}
-	msg, err = ch.SendMessage(context.Background(), msg, userB.ID)
+	resp, err = ch.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
+
+	msg = resp.Message
 	require.Equal(t, false, msg.Shadowed)
 
 	msg, err = c.GetMessage(context.Background(), msg.ID)
@@ -61,8 +67,10 @@ func TestClient_ShadowBanUser(t *testing.T) {
 	require.NoError(t, err)
 
 	msg = &Message{Text: "test message"}
-	msg, err = ch.SendMessage(context.Background(), msg, userC.ID)
+	resp, err = ch.SendMessage(context.Background(), msg, userC.ID)
 	require.NoError(t, err)
+
+	msg = resp.Message
 	require.Equal(t, false, msg.Shadowed)
 
 	msg, err = c.GetMessage(context.Background(), msg.ID)

--- a/user_test.go
+++ b/user_test.go
@@ -101,11 +101,13 @@ func TestClient_MuteUser(t *testing.T) {
 	err := c.MuteUser(context.Background(), randomUser(t, c).ID, user.ID, nil)
 	require.NoError(t, err, "MuteUser should not return an error")
 
-	users, err := c.QueryUsers(context.Background(), &QueryOption{
+	resp, err := c.QueryUsers(context.Background(), &QueryOption{
 		Filter: map[string]interface{}{
 			"id": map[string]string{"$eq": user.ID},
 		},
 	})
+
+	users := resp.Users
 	require.NoError(t, err, "QueryUsers should not return an error")
 	require.NotEmptyf(t, users, "QueryUsers should return a user: %+v", users)
 	require.NotEmptyf(t, users[0].Mutes, "user should have Mutes: %+v", users[0])
@@ -120,11 +122,13 @@ func TestClient_MuteUser(t *testing.T) {
 	err = c.MuteUser(context.Background(), randomUser(t, c).ID, user.ID, map[string]interface{}{"timeout": 60})
 	require.NoError(t, err, "MuteUser should not return an error")
 
-	users, err = c.QueryUsers(context.Background(), &QueryOption{
+	resp, err = c.QueryUsers(context.Background(), &QueryOption{
 		Filter: map[string]interface{}{
 			"id": map[string]string{"$eq": user.ID},
 		},
 	})
+
+	users = resp.Users
 	require.NoError(t, err, "QueryUsers should not return an error")
 	require.NotEmptyf(t, users, "QueryUsers should return a user: %+v", users)
 	require.NotEmptyf(t, users[0].Mutes, "user should have Mutes: %+v", users[0])
@@ -144,11 +148,13 @@ func TestClient_MuteUsers(t *testing.T) {
 	err := c.MuteUsers(context.Background(), targetIDs, user.ID, map[string]interface{}{"timeout": 60})
 	require.NoError(t, err, "MuteUsers should not return an error")
 
-	users, err := c.QueryUsers(context.Background(), &QueryOption{
+	resp, err := c.QueryUsers(context.Background(), &QueryOption{
 		Filter: map[string]interface{}{
 			"id": map[string]string{"$eq": user.ID},
 		},
 	})
+
+	users := resp.Users
 	require.NoError(t, err, "QueryUsers should not return an error")
 	require.NotEmptyf(t, users, "QueryUsers should return a user: %+v", users)
 	require.NotEmptyf(t, users[0].Mutes, "user should have Mutes: %+v", users[0])

--- a/user_test.go
+++ b/user_test.go
@@ -16,22 +16,24 @@ func TestClient_ShadowBanUser(t *testing.T) {
 	userC := randomUser(t, c)
 
 	ch := initChannel(t, c, userA.ID, userB.ID, userC.ID)
-	ch, err := c.CreateChannel(context.Background(), ch.Type, ch.ID, userA.ID, nil)
+	resp, err := c.CreateChannel(context.Background(), ch.Type, ch.ID, userA.ID, nil)
 	require.NoError(t, err)
 
+	ch = resp.Channel
+
 	// shadow ban userB globally
-	err = c.ShadowBan(context.Background(), userB.ID, userA.ID, nil)
+	_, err = c.ShadowBan(context.Background(), userB.ID, userA.ID, nil)
 	require.NoError(t, err)
 
 	// shadow ban userC on channel
-	err = ch.ShadowBan(context.Background(), userC.ID, userA.ID, nil)
+	_, err = ch.ShadowBan(context.Background(), userC.ID, userA.ID, nil)
 	require.NoError(t, err)
 
 	msg := &Message{Text: "test message"}
-	resp, err := ch.SendMessage(context.Background(), msg, userB.ID)
+	resp1, err := ch.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
 
-	msg = resp.Message
+	msg = resp1.Message
 	require.Equal(t, false, msg.Shadowed)
 
 	msg, err = c.GetMessage(context.Background(), msg.ID)
@@ -39,38 +41,38 @@ func TestClient_ShadowBanUser(t *testing.T) {
 	require.Equal(t, true, msg.Shadowed)
 
 	msg = &Message{Text: "test message"}
-	resp, err = ch.SendMessage(context.Background(), msg, userC.ID)
+	resp1, err = ch.SendMessage(context.Background(), msg, userC.ID)
 	require.NoError(t, err)
 
-	msg = resp.Message
+	msg = resp1.Message
 	require.Equal(t, false, msg.Shadowed)
 
 	msg, err = c.GetMessage(context.Background(), msg.ID)
 	require.NoError(t, err)
 	require.Equal(t, true, msg.Shadowed)
 
-	err = c.RemoveShadowBan(context.Background(), userB.ID, nil)
+	_, err = c.RemoveShadowBan(context.Background(), userB.ID, nil)
 	require.NoError(t, err)
 
 	msg = &Message{Text: "test message"}
-	resp, err = ch.SendMessage(context.Background(), msg, userB.ID)
+	resp1, err = ch.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
 
-	msg = resp.Message
+	msg = resp1.Message
 	require.Equal(t, false, msg.Shadowed)
 
 	msg, err = c.GetMessage(context.Background(), msg.ID)
 	require.NoError(t, err)
 	require.Equal(t, false, msg.Shadowed)
 
-	err = ch.RemoveShadowBan(context.Background(), userC.ID)
+	_, err = ch.RemoveShadowBan(context.Background(), userC.ID)
 	require.NoError(t, err)
 
 	msg = &Message{Text: "test message"}
-	resp, err = ch.SendMessage(context.Background(), msg, userC.ID)
+	resp1, err = ch.SendMessage(context.Background(), msg, userC.ID)
 	require.NoError(t, err)
 
-	msg = resp.Message
+	msg = resp1.Message
 	require.Equal(t, false, msg.Shadowed)
 
 	msg, err = c.GetMessage(context.Background(), msg.ID)
@@ -289,18 +291,18 @@ func ExampleClient_BanUser() {
 	client, _ := NewClient("XXXX", "XXXX")
 
 	// ban a user for 60 minutes from all channel
-	_ = client.BanUser(context.Background(), "eviluser", "modUser",
+	_, _ = client.BanUser(context.Background(), "eviluser", "modUser",
 		map[string]interface{}{"timeout": 60, "reason": "Banned for one hour"})
 
 	// ban a user from the livestream:fortnite channel
 	channel := client.Channel("livestream", "fortnite")
-	_ = channel.BanUser(context.Background(), "eviluser", "modUser",
+	_, _ = channel.BanUser(context.Background(), "eviluser", "modUser",
 		map[string]interface{}{"reason": "Profanity is not allowed here"})
 
 	// remove ban from channel
 	channel = client.Channel("livestream", "fortnite")
-	_ = channel.UnBanUser(context.Background(), "eviluser", nil)
+	_, _ = channel.UnBanUser(context.Background(), "eviluser", nil)
 
 	// remove global ban
-	_ = client.UnBanUser(context.Background(), "eviluser", nil)
+	_, _ = client.UnBanUser(context.Background(), "eviluser", nil)
 }

--- a/user_test.go
+++ b/user_test.go
@@ -30,54 +30,54 @@ func TestClient_ShadowBanUser(t *testing.T) {
 	require.NoError(t, err)
 
 	msg := &Message{Text: "test message"}
-	resp1, err := ch.SendMessage(context.Background(), msg, userB.ID)
+	messageResp, err := ch.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
 
-	msg = resp1.Message
+	msg = messageResp.Message
 	require.Equal(t, false, msg.Shadowed)
 
-	msg, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(context.Background(), msg.ID)
 	require.NoError(t, err)
-	require.Equal(t, true, msg.Shadowed)
+	require.Equal(t, true, messageResp.Message.Shadowed)
 
 	msg = &Message{Text: "test message"}
-	resp1, err = ch.SendMessage(context.Background(), msg, userC.ID)
+	messageResp, err = ch.SendMessage(context.Background(), msg, userC.ID)
 	require.NoError(t, err)
 
-	msg = resp1.Message
+	msg = messageResp.Message
 	require.Equal(t, false, msg.Shadowed)
 
-	msg, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(context.Background(), msg.ID)
 	require.NoError(t, err)
-	require.Equal(t, true, msg.Shadowed)
+	require.Equal(t, true, messageResp.Message.Shadowed)
 
 	_, err = c.RemoveShadowBan(context.Background(), userB.ID, nil)
 	require.NoError(t, err)
 
 	msg = &Message{Text: "test message"}
-	resp1, err = ch.SendMessage(context.Background(), msg, userB.ID)
+	messageResp, err = ch.SendMessage(context.Background(), msg, userB.ID)
 	require.NoError(t, err)
 
-	msg = resp1.Message
+	msg = messageResp.Message
 	require.Equal(t, false, msg.Shadowed)
 
-	msg, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(context.Background(), msg.ID)
 	require.NoError(t, err)
-	require.Equal(t, false, msg.Shadowed)
+	require.Equal(t, false, messageResp.Message.Shadowed)
 
 	_, err = ch.RemoveShadowBan(context.Background(), userC.ID)
 	require.NoError(t, err)
 
 	msg = &Message{Text: "test message"}
-	resp1, err = ch.SendMessage(context.Background(), msg, userC.ID)
+	messageResp, err = ch.SendMessage(context.Background(), msg, userC.ID)
 	require.NoError(t, err)
 
-	msg = resp1.Message
+	msg = messageResp.Message
 	require.Equal(t, false, msg.Shadowed)
 
-	msg, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(context.Background(), msg.ID)
 	require.NoError(t, err)
-	require.Equal(t, false, msg.Shadowed)
+	require.Equal(t, false, messageResp.Message.Shadowed)
 }
 
 func TestClient_BanUser(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -33,12 +33,12 @@ func clearOldChannelTypes() error {
 	}
 	c.BaseURL = defaultBaseURL
 
-	got, err := c.ListChannelTypes(context.Background())
+	resp, err := c.ListChannelTypes(context.Background())
 	if err != nil {
 		return err
 	}
 
-	for _, ct := range got {
+	for _, ct := range resp.ChannelTypes {
 		if contains(defaultChannelTypes, ct.Name) {
 			continue
 		}
@@ -54,7 +54,7 @@ func clearOldChannelTypes() error {
 		}
 
 		if !hasChannel {
-			_ = c.DeleteChannelType(context.Background(), ct.Name)
+			_, _ = c.DeleteChannelType(context.Background(), ct.Name)
 		}
 	}
 	return nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -43,10 +43,10 @@ func clearOldChannelTypes() error {
 			continue
 		}
 		filter := map[string]interface{}{"type": ct.Name}
-		chs, _ := c.QueryChannels(context.Background(), &QueryOption{Filter: filter})
+		resp, _ := c.QueryChannels(context.Background(), &QueryOption{Filter: filter})
 
 		hasChannel := false
-		for _, ch := range chs {
+		for _, ch := range resp.Channels {
 			if _, err := ch.Delete(context.Background()); err != nil {
 				hasChannel = true
 				break

--- a/utils_test.go
+++ b/utils_test.go
@@ -61,9 +61,9 @@ func clearOldChannelTypes() error {
 }
 
 func randomUser(t *testing.T, c *Client) *User {
-	u, err := c.UpsertUser(context.Background(), &User{ID: randomString(10)})
+	resp, err := c.UpsertUser(context.Background(), &User{ID: randomString(10)})
 	require.NoError(t, err)
-	return u
+	return resp.User
 }
 
 func randomUsers(t *testing.T, c *Client, n int) []*User {
@@ -72,10 +72,10 @@ func randomUsers(t *testing.T, c *Client, n int) []*User {
 		users = append(users, &User{ID: randomString(10)})
 	}
 
-	userss, err := c.UpsertUsers(context.Background(), users...)
+	resp, err := c.UpsertUsers(context.Background(), users...)
 	require.NoError(t, err)
 	users = users[:0]
-	for _, user := range userss {
+	for _, user := range resp.Users {
 		users = append(users, user)
 	}
 	return users

--- a/utils_test.go
+++ b/utils_test.go
@@ -47,7 +47,7 @@ func clearOldChannelTypes() error {
 
 		hasChannel := false
 		for _, ch := range chs {
-			if err := ch.Delete(context.Background()); err != nil {
+			if _, err := ch.Delete(context.Background()); err != nil {
 				hasChannel = true
 				break
 			}


### PR DESCRIPTION
This PR adds a base response type `Response` which holds rate limit information computed from response headers.

Breaking changes:
- All methods return now two parameter: a `*Response` and an error
- Except the ones that return specific types, those types have now a `Response` embedded
- Some types have been now exposed eg. `sendFileResponse` is now `SendFileResponse` and contain the `Response` 