### PR TITLE
Drop unflag message/user

### DIFF
--- a/message.go
+++ b/message.go
@@ -404,22 +404,6 @@ func (c *Client) FlagMessage(ctx context.Context, msgID, userID string) error {
 	return c.makeRequest(ctx, http.MethodPost, "moderation/flag", nil, options, nil)
 }
 
-func (c *Client) UnflagMessage(ctx context.Context, msgID, userID string) error {
-	if msgID == "" {
-		return errors.New("message ID is empty")
-	}
-
-	if userID == "" {
-		return errors.New("user ID is empty")
-	}
-
-	options := map[string]interface{}{
-		"target_message_id": msgID,
-		"user_id":           userID,
-	}
-	return c.makeRequest(ctx, http.MethodPost, "moderation/unflag", nil, options, nil)
-}
-
 type repliesResponse struct {
 	Messages []*Message `json:"messages"`
 }

--- a/query_test.go
+++ b/query_test.go
@@ -290,16 +290,10 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, got, 1)
 
-	// unflag these 2 messages
-	err = c.UnflagMessage(context.Background(), msg1.ID, user2.ID)
-	require.NoError(t, err)
-	err = c.UnflagMessage(context.Background(), msg2.ID, user1.ID)
-	require.NoError(t, err)
-
 	// none should show up
 	got, err = c.QueryMessageFlags(context.Background(), &QueryOption{
 		Filter: map[string]interface{}{"channel_cid": ch.cid()},
 	})
 	require.NoError(t, err)
-	assert.Len(t, got, 0)
+	assert.Len(t, got, 2)
 }

--- a/user.go
+++ b/user.go
@@ -165,19 +165,6 @@ func (c *Client) FlagUser(ctx context.Context, targetID string, options map[stri
 	return c.makeRequest(ctx, http.MethodPost, "moderation/flag", nil, options, nil)
 }
 
-func (c *Client) UnFlagUser(ctx context.Context, targetID string, options map[string]interface{}) error {
-	switch {
-	case targetID == "":
-		return errors.New("target ID is empty")
-	case options == nil:
-		options = map[string]interface{}{}
-	}
-
-	options["target_user_id"] = targetID
-
-	return c.makeRequest(ctx, http.MethodPost, "moderation/unflag", nil, options, nil)
-}
-
 func (c *Client) BanUser(ctx context.Context, targetID, userID string, options map[string]interface{}) error {
 	switch {
 	case targetID == "":

--- a/user_test.go
+++ b/user_test.go
@@ -151,9 +151,6 @@ func TestClient_MuteUsers(t *testing.T) {
 func TestClient_UnBanUser(t *testing.T) {
 }
 
-func TestClient_UnFlagUser(t *testing.T) {
-}
-
 func TestClient_UnmuteUser(t *testing.T) {
 	c := initClient(t)
 


### PR DESCRIPTION
This is deprecated and does nothing from now. Since we do major, good to drop for SDK
