### PR TITLE
feat: add grants to channeltype

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,6 +32,3 @@ jobs:
           STREAM_CHAT_API_KEY: ${{ secrets.STREAM_CHAT_API_KEY }}
           STREAM_CHAT_API_SECRET: ${{ secrets.STREAM_CHAT_API_SECRET }}
         run: go test -v -race ./...
-
-      - name: Build on ${{ matrix.goVer }}
-        run: go build ./...

--- a/app.go
+++ b/app.go
@@ -7,13 +7,16 @@ import (
 )
 
 type AppSettings struct {
-	DisableAuth           *bool           `json:"disable_auth_checks,omitempty"`
-	DisablePermissions    *bool           `json:"disable_permissions_checks,omitempty"`
-	APNConfig             *APNConfig      `json:"apn_config,omitempty"`
-	FirebaseConfig        *FirebaseConfig `json:"firebase_config,omitempty"`
-	WebhookURL            *string         `json:"webhook_url,omitempty"`
-	MultiTenantEnabled    *bool           `json:"multi_tenant_enabled,omitempty"`
-	AsyncURLEnrichEnabled *bool           `json:"async_url_enrich_enabled,omitempty"`
+	DisableAuth            *bool               `json:"disable_auth_checks,omitempty"`
+	DisablePermissions     *bool               `json:"disable_permissions_checks,omitempty"`
+	APNConfig              *APNConfig          `json:"apn_config,omitempty"`
+	FirebaseConfig         *FirebaseConfig     `json:"firebase_config,omitempty"`
+	WebhookURL             *string             `json:"webhook_url,omitempty"`
+	MultiTenantEnabled     *bool               `json:"multi_tenant_enabled,omitempty"`
+	AsyncURLEnrichEnabled  *bool               `json:"async_url_enrich_enabled,omitempty"`
+	Grants                 map[string][]string `json:"grants,omitempty"`
+	MigratePermissionsToV2 *bool               `json:"migrate_permissions_to_v2,omitempty"`
+	PermissionVersion      string              `json:"permission_version,omitempty"`
 }
 
 func (a *AppSettings) SetDisableAuth(b bool) *AppSettings {
@@ -43,6 +46,11 @@ func (a *AppSettings) SetWebhookURL(s string) *AppSettings {
 
 func (a *AppSettings) SetMultiTenant(b bool) *AppSettings {
 	a.MultiTenantEnabled = &b
+	return a
+}
+
+func (a *AppSettings) SetGrants(g map[string][]string) *AppSettings {
+	a.Grants = g
 	return a
 }
 
@@ -99,6 +107,8 @@ type AppConfig struct {
 	MultiTenantEnabled       bool                      `json:"multi_tenant_enabled"`
 	RevokeTokensIssuedBefore *time.Time                `json:"revoke_tokens_issued_before"`
 	AsyncURLEnrichEnabled    bool                      `json:"async_url_enrich_enabled"`
+	Grants                   map[string][]string       `json:"grants"`
+	PermissionVersion        string                    `json:"permission_version"`
 }
 
 type AppResponse struct {

--- a/channel_type.go
+++ b/channel_type.go
@@ -53,6 +53,7 @@ type ChannelType struct {
 	// that can be found in permission_client.go.
 	// See https://getstream.io/chat/docs/go-golang/migrating_from_legacy/?language=go
 	Permissions []*ChannelTypePermission `json:"permissions"`
+	Grants      map[string][]string      `json:"grants"`
 
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -34,6 +34,7 @@ func TestClient_GetChannelType(t *testing.T) {
 	assert.Equal(t, ct.Name, resp.ChannelType.Name)
 	assert.Equal(t, len(ct.Commands), len(resp.ChannelType.Commands))
 	assert.Equal(t, ct.Permissions, resp.ChannelType.Permissions)
+	assert.NotEmpty(t, resp.Grants)
 }
 
 func TestClient_ListChannelTypes(t *testing.T) {


### PR DESCRIPTION
In order to fill up the code snippet examples in the [Permission V2 docs page](https://getstream.io/chat/docs/java/user_permissions/?preview=1&language=go), we need to be able to update grants on channel type level.

So basically this is support for ChannelType grants.