### PR TITLE
test: refactor tests for cleanup

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -10,18 +10,20 @@ import (
 
 func TestClient_GetApp(t *testing.T) {
 	c := initClient(t)
-	_, err := c.GetAppConfig(context.Background())
+	ctx := context.Background()
+	_, err := c.GetAppConfig(ctx)
 	require.NoError(t, err)
 }
 
 func TestClient_UpdateAppSettings(t *testing.T) {
 	c := initClient(t)
+	ctx := context.Background()
 
 	settings := NewAppSettings().
 		SetDisableAuth(true).
 		SetDisablePermissions(true)
 
-	_, err := c.UpdateAppSettings(context.Background(), settings)
+	_, err := c.UpdateAppSettings(ctx, settings)
 	require.NoError(t, err)
 }
 
@@ -60,16 +62,17 @@ func ExampleClient_UpdateAppSettings_disable_auth() {
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
+	ctx := context.Background()
 
 	// disable auth checks, allows dev token usage
 	settings := NewAppSettings().SetDisableAuth(true)
-	_, err = client.UpdateAppSettings(context.Background(), settings)
+	_, err = client.UpdateAppSettings(ctx, settings)
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
 
 	// re-enable auth checks
-	_, err = client.UpdateAppSettings(context.Background(), NewAppSettings().SetDisableAuth(false))
+	_, err = client.UpdateAppSettings(ctx, NewAppSettings().SetDisableAuth(false))
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
@@ -80,16 +83,17 @@ func ExampleClient_UpdateAppSettings_disable_permission() {
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
+	ctx := context.Background()
 
 	// disable permission checkse
 	settings := NewAppSettings().SetDisablePermissions(true)
-	_, err = client.UpdateAppSettings(context.Background(), settings)
+	_, err = client.UpdateAppSettings(ctx, settings)
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}
 
 	// re-enable permission checks
-	_, err = client.UpdateAppSettings(context.Background(), NewAppSettings().SetDisablePermissions(false))
+	_, err = client.UpdateAppSettings(ctx, NewAppSettings().SetDisablePermissions(false))
 	if err != nil {
 		log.Fatalf("Err: %v", err)
 	}

--- a/ban_test.go
+++ b/ban_test.go
@@ -12,68 +12,69 @@ func TestShadowBanUser(t *testing.T) {
 	userA := randomUser(t, c)
 	userB := randomUser(t, c)
 	userC := randomUser(t, c)
+	ctx := context.Background()
 
 	ch := initChannel(t, c, userA.ID, userB.ID, userC.ID)
-	resp, err := c.CreateChannel(context.Background(), ch.Type, ch.ID, userA.ID, nil)
+	resp, err := c.CreateChannel(ctx, ch.Type, ch.ID, userA.ID, nil)
 	require.NoError(t, err)
 
 	ch = resp.Channel
 
 	// shadow ban userB globally
-	_, err = c.ShadowBan(context.Background(), userB.ID, userA.ID)
+	_, err = c.ShadowBan(ctx, userB.ID, userA.ID)
 	require.NoError(t, err)
 
 	// shadow ban userC on channel
-	_, err = ch.ShadowBan(context.Background(), userC.ID, userA.ID)
+	_, err = ch.ShadowBan(ctx, userC.ID, userA.ID)
 	require.NoError(t, err)
 
 	msg := &Message{Text: "test message"}
-	messageResp, err := ch.SendMessage(context.Background(), msg, userB.ID)
+	messageResp, err := ch.SendMessage(ctx, msg, userB.ID)
 	require.NoError(t, err)
 
 	msg = messageResp.Message
 	require.Equal(t, false, msg.Shadowed)
 
-	messageResp, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(ctx, msg.ID)
 	require.NoError(t, err)
 	require.Equal(t, true, messageResp.Message.Shadowed)
 
 	msg = &Message{Text: "test message"}
-	messageResp, err = ch.SendMessage(context.Background(), msg, userC.ID)
+	messageResp, err = ch.SendMessage(ctx, msg, userC.ID)
 	require.NoError(t, err)
 
 	msg = messageResp.Message
 	require.Equal(t, false, msg.Shadowed)
 
-	messageResp, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(ctx, msg.ID)
 	require.NoError(t, err)
 	require.Equal(t, true, messageResp.Message.Shadowed)
 
-	_, err = c.UnBanUser(context.Background(), userB.ID)
+	_, err = c.UnBanUser(ctx, userB.ID)
 	require.NoError(t, err)
 
 	msg = &Message{Text: "test message"}
-	messageResp, err = ch.SendMessage(context.Background(), msg, userB.ID)
+	messageResp, err = ch.SendMessage(ctx, msg, userB.ID)
 	require.NoError(t, err)
 
 	msg = messageResp.Message
 	require.Equal(t, false, msg.Shadowed)
 
-	messageResp, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(ctx, msg.ID)
 	require.NoError(t, err)
 	require.Equal(t, false, messageResp.Message.Shadowed)
 
-	_, err = ch.UnBanUser(context.Background(), userC.ID)
+	_, err = ch.UnBanUser(ctx, userC.ID)
 	require.NoError(t, err)
 
 	msg = &Message{Text: "test message"}
-	messageResp, err = ch.SendMessage(context.Background(), msg, userC.ID)
+	messageResp, err = ch.SendMessage(ctx, msg, userC.ID)
 	require.NoError(t, err)
 
 	msg = messageResp.Message
 	require.Equal(t, false, msg.Shadowed)
 
-	messageResp, err = c.GetMessage(context.Background(), msg.ID)
+	messageResp, err = c.GetMessage(ctx, msg.ID)
 	require.NoError(t, err)
 	require.Equal(t, false, messageResp.Message.Shadowed)
 }
@@ -82,11 +83,12 @@ func TestBanUnbanUser(t *testing.T) {
 	c := initClient(t)
 	target := randomUser(t, c)
 	user := randomUser(t, c)
+	ctx := context.Background()
 
-	_, err := c.BanUser(context.Background(), target.ID, user.ID, BanWithReason("spammer"), BanWithExpiration(60))
+	_, err := c.BanUser(ctx, target.ID, user.ID, BanWithReason("spammer"), BanWithExpiration(60))
 	require.NoError(t, err)
 
-	resp, err := c.QueryBannedUsers(context.Background(), &QueryBannedUsersOptions{
+	resp, err := c.QueryBannedUsers(ctx, &QueryBannedUsersOptions{
 		QueryOption: &QueryOption{Filter: map[string]interface{}{
 			"user_id": map[string]string{"$eq": target.ID},
 		}},
@@ -95,10 +97,10 @@ func TestBanUnbanUser(t *testing.T) {
 	require.Equal(t, resp.Bans[0].Reason, "spammer")
 	require.NotZero(t, resp.Bans[0].Expires)
 
-	_, err = c.UnBanUser(context.Background(), target.ID)
+	_, err = c.UnBanUser(ctx, target.ID)
 	require.NoError(t, err)
 
-	resp, err = c.QueryBannedUsers(context.Background(), &QueryBannedUsersOptions{
+	resp, err = c.QueryBannedUsers(ctx, &QueryBannedUsersOptions{
 		QueryOption: &QueryOption{Filter: map[string]interface{}{
 			"user_id": map[string]string{"$eq": target.ID},
 		}},
@@ -111,16 +113,16 @@ func TestChannelBanUnban(t *testing.T) {
 	c := initClient(t)
 	target := randomUser(t, c)
 	user := randomUser(t, c)
-
 	ch := initChannel(t, c, user.ID, target.ID)
+	ctx := context.Background()
 
-	_, err := ch.BanUser(context.Background(), target.ID, user.ID, BanWithReason("spammer"), BanWithExpiration(60))
+	_, err := ch.BanUser(ctx, target.ID, user.ID, BanWithReason("spammer"), BanWithExpiration(60))
 	require.NoError(t, err)
 
-	_, err = ch.UnBanUser(context.Background(), target.ID)
+	_, err = ch.UnBanUser(ctx, target.ID)
 	require.NoError(t, err)
 
-	resp, err := c.QueryBannedUsers(context.Background(), &QueryBannedUsersOptions{
+	resp, err := c.QueryBannedUsers(ctx, &QueryBannedUsersOptions{
 		QueryOption: &QueryOption{Filter: map[string]interface{}{
 			"channel_cid": map[string]string{"$eq": ch.CID},
 		}},
@@ -131,18 +133,19 @@ func TestChannelBanUnban(t *testing.T) {
 
 func ExampleClient_BanUser() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
 	// ban a user for 60 minutes from all channel
-	_, _ = client.BanUser(context.Background(), "eviluser", "modUser", BanWithExpiration(60), BanWithReason("Banned for one hour"))
+	_, _ = client.BanUser(ctx, "eviluser", "modUser", BanWithExpiration(60), BanWithReason("Banned for one hour"))
 
 	// ban a user from the livestream:fortnite channel
 	channel := client.Channel("livestream", "fortnite")
-	_, _ = channel.BanUser(context.Background(), "eviluser", "modUser", BanWithReason("Profanity is not allowed here"))
+	_, _ = channel.BanUser(ctx, "eviluser", "modUser", BanWithReason("Profanity is not allowed here"))
 
 	// remove ban from channel
 	channel = client.Channel("livestream", "fortnite")
-	_, _ = channel.UnBanUser(context.Background(), "eviluser")
+	_, _ = channel.UnBanUser(ctx, "eviluser")
 
 	// remove global ban
-	_, _ = client.UnBanUser(context.Background(), "eviluser")
+	_, _ = client.UnBanUser(ctx, "eviluser")
 }

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -11,24 +11,25 @@ import (
 
 func prepareChannelType(t *testing.T, c *Client) *ChannelType {
 	ct := NewChannelType(randomString(10))
+	ctx := context.Background()
 
-	resp, err := c.CreateChannelType(context.Background(), ct)
+	resp, err := c.CreateChannelType(ctx, ct)
 	require.NoError(t, err, "create channel type")
-
 	time.Sleep(6 * time.Second)
+
+	t.Cleanup(func() {
+		_, _ = c.DeleteChannelType(ctx, ct.Name)
+	})
 
 	return resp.ChannelType
 }
 
 func TestClient_GetChannelType(t *testing.T) {
 	c := initClient(t)
-
 	ct := prepareChannelType(t, c)
-	defer func() {
-		_, _ = c.DeleteChannelType(context.Background(), ct.Name)
-	}()
+	ctx := context.Background()
 
-	resp, err := c.GetChannelType(context.Background(), ct.Name)
+	resp, err := c.GetChannelType(ctx, ct.Name)
 	require.NoError(t, err, "get channel type")
 
 	assert.Equal(t, ct.Name, resp.ChannelType.Name)
@@ -39,13 +40,10 @@ func TestClient_GetChannelType(t *testing.T) {
 
 func TestClient_ListChannelTypes(t *testing.T) {
 	c := initClient(t)
-
 	ct := prepareChannelType(t, c)
-	defer func() {
-		_, _ = c.DeleteChannelType(context.Background(), ct.Name)
-	}()
+	ctx := context.Background()
 
-	resp, err := c.ListChannelTypes(context.Background())
+	resp, err := c.ListChannelTypes(ctx)
 	require.NoError(t, err, "list channel types")
 
 	assert.Contains(t, resp.ChannelTypes, ct.Name)
@@ -53,19 +51,16 @@ func TestClient_ListChannelTypes(t *testing.T) {
 
 func TestClient_UpdateChannelTypePushNotifications(t *testing.T) {
 	c := initClient(t)
-
 	ct := prepareChannelType(t, c)
-	defer func() {
-		_, _ = c.DeleteChannelType(context.Background(), ct.Name)
-	}()
+	ctx := context.Background()
 
 	// default is on
 	require.True(t, ct.PushNotifications)
 
-	_, err := c.UpdateChannelType(context.Background(), ct.Name, map[string]interface{}{"push_notifications": false})
+	_, err := c.UpdateChannelType(ctx, ct.Name, map[string]interface{}{"push_notifications": false})
 	require.NoError(t, err)
 
-	resp, err := c.GetChannelType(context.Background(), ct.Name)
+	resp, err := c.GetChannelType(ctx, ct.Name)
 	require.NoError(t, err)
 	require.False(t, resp.ChannelType.PushNotifications)
 }
@@ -73,6 +68,7 @@ func TestClient_UpdateChannelTypePushNotifications(t *testing.T) {
 // See https://getstream.io/chat/docs/channel_features/ for more details.
 func ExampleClient_CreateChannelType() {
 	client := &Client{}
+	ctx := context.Background()
 
 	newChannelType := &ChannelType{
 		// Copy the default settings.
@@ -97,23 +93,26 @@ func ExampleClient_CreateChannelType() {
 		},
 	)
 
-	_, _ = client.CreateChannelType(context.Background(), newChannelType)
+	_, _ = client.CreateChannelType(ctx, newChannelType)
 }
 
 func ExampleClient_ListChannelTypes() {
 	client := &Client{}
-	_, _ = client.ListChannelTypes(context.Background())
+	ctx := context.Background()
+	_, _ = client.ListChannelTypes(ctx)
 }
 
 func ExampleClient_GetChannelType() {
 	client := &Client{}
-	_, _ = client.GetChannelType(context.Background(), "public")
+	ctx := context.Background()
+	_, _ = client.GetChannelType(ctx, "public")
 }
 
 func ExampleClient_UpdateChannelType() {
 	client := &Client{}
+	ctx := context.Background()
 
-	_, _ = client.UpdateChannelType(context.Background(), "public", map[string]interface{}{
+	_, _ = client.UpdateChannelType(ctx, "public", map[string]interface{}{
 		"permissions": []map[string]interface{}{
 			{
 				"name":      "Allow reads for all",
@@ -137,8 +136,9 @@ func ExampleClient_UpdateChannelType() {
 
 func ExampleClient_UpdateChannelType_bool() {
 	client := &Client{}
+	ctx := context.Background()
 
-	_, _ = client.UpdateChannelType(context.Background(), "public", map[string]interface{}{
+	_, _ = client.UpdateChannelType(ctx, "public", map[string]interface{}{
 		"typing_events":  false,
 		"read_events":    true,
 		"connect_events": true,
@@ -151,8 +151,9 @@ func ExampleClient_UpdateChannelType_bool() {
 
 func ExampleClient_UpdateChannelType_other() {
 	client := &Client{}
+	ctx := context.Background()
 
-	_, _ = client.UpdateChannelType(context.Background(),
+	_, _ = client.UpdateChannelType(ctx,
 		"public",
 		map[string]interface{}{
 			"automod":            "disabled",
@@ -165,8 +166,9 @@ func ExampleClient_UpdateChannelType_other() {
 
 func ExampleClient_UpdateChannelType_permissions() {
 	client := &Client{}
+	ctx := context.Background()
 
-	_, _ = client.UpdateChannelType(context.Background(),
+	_, _ = client.UpdateChannelType(ctx,
 		"public",
 		map[string]interface{}{
 			"permissions": []map[string]interface{}{
@@ -190,6 +192,7 @@ func ExampleClient_UpdateChannelType_permissions() {
 
 func ExampleClient_DeleteChannelType() {
 	client := &Client{}
+	ctx := context.Background()
 
-	_, _ = client.DeleteChannelType(context.Background(), "public")
+	_, _ = client.DeleteChannelType(ctx, "public")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -19,11 +19,16 @@ func initClient(t *testing.T) *Client {
 
 func initChannel(t *testing.T, c *Client, membersID ...string) *Channel {
 	owner := randomUser(t, c)
-	resp, err := c.CreateChannel(context.Background(), "team", randomString(12), owner.ID, map[string]interface{}{
+	ctx := context.Background()
+	resp, err := c.CreateChannel(ctx, "team", randomString(12), owner.ID, map[string]interface{}{
 		"members": membersID,
 	})
-
 	require.NoError(t, err, "create channel")
+
+	t.Cleanup(func() {
+		_, _ = c.DeleteChannels(ctx, []string{resp.Channel.CID}, true)
+	})
+
 	return resp.Channel
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -13,22 +13,24 @@ func prepareCommand(t *testing.T, c *Client) *Command {
 		Name:        randomString(10),
 		Description: "test command",
 	}
+	ctx := context.Background()
 
-	resp, err := c.CreateCommand(context.Background(), cmd)
+	resp, err := c.CreateCommand(ctx, cmd)
 	require.NoError(t, err, "create command")
+
+	t.Cleanup(func() {
+		_, _ = c.DeleteCommand(ctx, cmd.Name)
+	})
 
 	return resp.Command
 }
 
 func TestClient_GetCommand(t *testing.T) {
 	c := initClient(t)
-
 	cmd := prepareCommand(t, c)
-	defer func() {
-		_, _ = c.DeleteCommand(context.Background(), cmd.Name)
-	}()
+	ctx := context.Background()
 
-	resp, err := c.GetCommand(context.Background(), cmd.Name)
+	resp, err := c.GetCommand(ctx, cmd.Name)
 	require.NoError(t, err, "get command")
 
 	assert.Equal(t, cmd.Name, resp.Command.Name)
@@ -37,13 +39,10 @@ func TestClient_GetCommand(t *testing.T) {
 
 func TestClient_ListCommands(t *testing.T) {
 	c := initClient(t)
-
 	cmd := prepareCommand(t, c)
-	defer func() {
-		_, _ = c.DeleteCommand(context.Background(), cmd.Name)
-	}()
+	ctx := context.Background()
 
-	resp, err := c.ListCommands(context.Background())
+	resp, err := c.ListCommands(ctx)
 	require.NoError(t, err, "list commands")
 
 	assert.Contains(t, resp.Commands, cmd)
@@ -51,14 +50,11 @@ func TestClient_ListCommands(t *testing.T) {
 
 func TestClient_UpdateCommand(t *testing.T) {
 	c := initClient(t)
-
 	cmd := prepareCommand(t, c)
-	defer func() {
-		_, _ = c.DeleteCommand(context.Background(), cmd.Name)
-	}()
+	ctx := context.Background()
 
 	update := Command{Description: "new description"}
-	resp, err := c.UpdateCommand(context.Background(), cmd.Name, &update)
+	resp, err := c.UpdateCommand(ctx, cmd.Name, &update)
 	require.NoError(t, err, "update command")
 
 	assert.Equal(t, cmd.Name, resp.Command.Name)
@@ -68,6 +64,7 @@ func TestClient_UpdateCommand(t *testing.T) {
 // See https://getstream.io/chat/docs/custom_commands/ for more details.
 func ExampleClient_CreateCommand() {
 	client := &Client{}
+	ctx := context.Background()
 
 	newCommand := &Command{
 		Name:        "my-command",
@@ -76,28 +73,32 @@ func ExampleClient_CreateCommand() {
 		Set:         "custom_cmd_set",
 	}
 
-	_, _ = client.CreateCommand(context.Background(), newCommand)
+	_, _ = client.CreateCommand(ctx, newCommand)
 }
 
 func ExampleClient_ListCommands() {
 	client := &Client{}
-	_, _ = client.ListCommands(context.Background())
+	ctx := context.Background()
+	_, _ = client.ListCommands(ctx)
 }
 
 func ExampleClient_GetCommand() {
 	client := &Client{}
-	_, _ = client.GetCommand(context.Background(), "my-command")
+	ctx := context.Background()
+	_, _ = client.GetCommand(ctx, "my-command")
 }
 
 func ExampleClient_UpdateCommand() {
 	client := &Client{}
+	ctx := context.Background()
 
 	update := Command{Description: "updated description"}
-	_, _ = client.UpdateCommand(context.Background(), "my-command", &update)
+	_, _ = client.UpdateCommand(ctx, "my-command", &update)
 }
 
 func ExampleClient_DeleteCommand() {
 	client := &Client{}
+	ctx := context.Background()
 
-	_, _ = client.DeleteCommand(context.Background(), "my-command")
+	_, _ = client.DeleteCommand(ctx, "my-command")
 }

--- a/device_test.go
+++ b/device_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestClient_Devices(t *testing.T) {
 	c := initClient(t)
-
+	ctx := context.Background()
 	user := randomUser(t, c)
 
 	devices := []*Device{
@@ -19,14 +19,14 @@ func TestClient_Devices(t *testing.T) {
 	}
 
 	for _, dev := range devices {
-		_, err := c.AddDevice(context.Background(), dev)
+		_, err := c.AddDevice(ctx, dev)
 		require.NoError(t, err, "add device")
 
-		resp, err := c.GetDevices(context.Background(), user.ID)
+		resp, err := c.GetDevices(ctx, user.ID)
 		require.NoError(t, err, "get devices")
 
 		assert.True(t, deviceIDExists(resp.Devices, dev.ID), "device with ID %s was created", dev.ID)
-		_, err = c.DeleteDevice(context.Background(), user.ID, dev.ID)
+		_, err = c.DeleteDevice(ctx, user.ID, dev.ID)
 		require.NoError(t, err, "delete device")
 	}
 }
@@ -42,8 +42,9 @@ func deviceIDExists(dev []*Device, id string) bool {
 
 func ExampleClient_AddDevice() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
-	_, _ = client.AddDevice(context.Background(), &Device{
+	_, _ = client.AddDevice(ctx, &Device{
 		ID:           "2ffca4ad6599adc9b5202d15a5286d33c19547d472cd09de44219cda5ac30207",
 		UserID:       "elon",
 		PushProvider: PushProviderAPNS,
@@ -52,8 +53,9 @@ func ExampleClient_AddDevice() {
 
 func ExampleClient_DeleteDevice() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
 	deviceID := "2ffca4ad6599adc9b5202d15a5286d33c19547d472cd09de44219cda5ac30207"
 	userID := "elon"
-	_, _ = client.DeleteDevice(context.Background(), userID, deviceID)
+	_, _ = client.DeleteDevice(ctx, userID, deviceID)
 }

--- a/event_test.go
+++ b/event_test.go
@@ -46,6 +46,7 @@ func TestEventSupportsAllFields(t *testing.T) {
 
 func TestSendUserCustomEvent(t *testing.T) {
 	c := initClient(t)
+	ctx := context.Background()
 
 	tests := []struct {
 		name         string
@@ -77,11 +78,11 @@ func TestSendUserCustomEvent(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.expectedErr == "" {
-				_, err := c.UpsertUser(context.Background(), &User{ID: test.targetUserID})
+				_, err := c.UpsertUser(ctx, &User{ID: test.targetUserID})
 				require.NoError(t, err)
 			}
 
-			_, err := c.SendUserCustomEvent(context.Background(), test.targetUserID, test.event)
+			_, err := c.SendUserCustomEvent(ctx, test.targetUserID, test.event)
 
 			if test.expectedErr == "" {
 				require.NoError(t, err)

--- a/http_test.go
+++ b/http_test.go
@@ -14,6 +14,7 @@ import (
 // We use DeleteUsers endpoint, it requires a very low number of requests (6/min).
 func TestRateLimit(t *testing.T) {
 	c := initClient(t)
+	ctx := context.Background()
 
 	users := make([]*User, 0, 8)
 	for i := 0; i < 8; i++ {
@@ -21,7 +22,7 @@ func TestRateLimit(t *testing.T) {
 	}
 
 	for _, u := range users {
-		_, err := c.DeleteUsers(context.Background(), []string{u.ID}, DeleteUserOptions{
+		_, err := c.DeleteUsers(ctx, []string{u.ID}, DeleteUserOptions{
 			User:     SoftDelete,
 			Messages: HardDelete,
 		})
@@ -42,8 +43,9 @@ func TestRateLimit(t *testing.T) {
 func TestContextExceeded(t *testing.T) {
 	c := initClient(t)
 	user := randomUser(t, c)
+	ctx := context.Background()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, time.Millisecond)
 	defer cancel()
 
 	_, err := c.DeleteUsers(ctx, []string{user.ID}, DeleteUserOptions{

--- a/rate_limits_test.go
+++ b/rate_limits_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestClient_GetRateLimits(t *testing.T) {
 	c := initClient(t)
+	ctx := context.Background()
 
 	t.Run("get all limits", func(t *testing.T) {
-		limits, err := c.GetRateLimits(context.Background())
+		limits, err := c.GetRateLimits(ctx)
 		require.NoError(t, err)
 		require.NotEmpty(t, limits.Android)
 		require.NotEmpty(t, limits.Web)
@@ -20,7 +21,7 @@ func TestClient_GetRateLimits(t *testing.T) {
 	})
 
 	t.Run("get only a single platform", func(t *testing.T) {
-		limits, err := c.GetRateLimits(context.Background(), WithServerSide())
+		limits, err := c.GetRateLimits(ctx, WithServerSide())
 		require.NoError(t, err)
 		require.Empty(t, limits.Android)
 		require.Empty(t, limits.Web)
@@ -29,7 +30,7 @@ func TestClient_GetRateLimits(t *testing.T) {
 	})
 
 	t.Run("get only a few endpoints", func(t *testing.T) {
-		limits, err := c.GetRateLimits(context.Background(),
+		limits, err := c.GetRateLimits(ctx,
 			WithServerSide(),
 			WithAndroid(),
 			WithEndpoints(

--- a/reaction_test.go
+++ b/reaction_test.go
@@ -13,12 +13,13 @@ func ExampleChannel_SendReaction() {
 	channel := &Channel{}
 	msgID := "123"
 	userID := "bob-1"
+	ctx := context.Background()
 
 	reaction := &Reaction{
 		Type:      "love",
 		ExtraData: map[string]interface{}{"my_custom_field": 123},
 	}
-	_, err := channel.SendReaction(context.Background(), reaction, msgID, userID)
+	_, err := channel.SendReaction(ctx, reaction, msgID, userID)
 	if err != nil {
 		log.Fatalf("Found Error: %v", err)
 	}
@@ -27,21 +28,18 @@ func ExampleChannel_SendReaction() {
 func TestChannel_SendReaction(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
-	defer func() {
-		_, err := ch.Delete(context.Background())
-		require.NoError(t, err, "delete channel")
-	}()
-
 	user := randomUser(t, c)
+	ctx := context.Background()
 	msg := &Message{
 		Text: "test message",
 		User: user,
 	}
-	resp, err := ch.SendMessage(context.Background(), msg, user.ID)
+
+	resp, err := ch.SendMessage(ctx, msg, user.ID)
 	require.NoError(t, err, "send message")
 
 	reaction := Reaction{Type: "love"}
-	reactionResp, err := ch.SendReaction(context.Background(), &reaction, resp.Message.ID, user.ID)
+	reactionResp, err := ch.SendReaction(ctx, &reaction, resp.Message.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
 	assert.Equal(t, 1, reactionResp.Message.ReactionCounts[reaction.Type], "reaction count", reaction)
@@ -63,24 +61,21 @@ func reactionExistsCondition(reactions []*Reaction, searchType string) func() bo
 func TestChannel_DeleteReaction(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
-	defer func() {
-		_, err := ch.Delete(context.Background())
-		require.NoError(t, err, "delete channel")
-	}()
-
 	user := randomUser(t, c)
+	ctx := context.Background()
 	msg := &Message{
 		Text: "test message",
 		User: user,
 	}
-	resp, err := ch.SendMessage(context.Background(), msg, user.ID)
+
+	resp, err := ch.SendMessage(ctx, msg, user.ID)
 	require.NoError(t, err, "send message")
 
 	reaction := Reaction{Type: "love"}
-	reactionResp, err := ch.SendReaction(context.Background(), &reaction, resp.Message.ID, user.ID)
+	reactionResp, err := ch.SendReaction(ctx, &reaction, resp.Message.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
-	reactionResp, err = ch.DeleteReaction(context.Background(), reactionResp.Message.ID, reaction.Type, user.ID)
+	reactionResp, err = ch.DeleteReaction(ctx, reactionResp.Message.ID, reaction.Type, user.ID)
 	require.NoError(t, err, "delete reaction")
 
 	assert.Equal(t, 0, reactionResp.Message.ReactionCounts[reaction.Type], "reaction count")
@@ -90,30 +85,27 @@ func TestChannel_DeleteReaction(t *testing.T) {
 func TestChannel_GetReactions(t *testing.T) {
 	c := initClient(t)
 	ch := initChannel(t, c)
-	defer func() {
-		_, err := ch.Delete(context.Background())
-		require.NoError(t, err, "delete channel")
-	}()
-
 	user := randomUser(t, c)
+	ctx := context.Background()
 	msg := &Message{
 		Text: "test message",
 		User: user,
 	}
-	resp, err := ch.SendMessage(context.Background(), msg, user.ID)
+
+	resp, err := ch.SendMessage(ctx, msg, user.ID)
 	require.NoError(t, err, "send message")
 	msg = resp.Message
 
-	reactionsResp, err := ch.GetReactions(context.Background(), msg.ID, nil)
+	reactionsResp, err := ch.GetReactions(ctx, msg.ID, nil)
 	require.NoError(t, err, "get reactions")
 	assert.Empty(t, reactionsResp.Reactions, "reactions empty")
 
 	reaction := Reaction{Type: "love"}
 
-	reactionResp, err := ch.SendReaction(context.Background(), &reaction, msg.ID, user.ID)
+	reactionResp, err := ch.SendReaction(ctx, &reaction, msg.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
-	reactionsResp, err = ch.GetReactions(context.Background(), reactionResp.Message.ID, nil)
+	reactionsResp, err = ch.GetReactions(ctx, reactionResp.Message.ID, nil)
 	require.NoError(t, err, "get reactions")
 
 	assert.Condition(t, reactionExistsCondition(reactionsResp.Reactions, reaction.Type), "reaction exists")

--- a/user_test.go
+++ b/user_test.go
@@ -22,12 +22,13 @@ func TestClient_FlagUser(t *testing.T) {
 
 func TestClient_MuteUser(t *testing.T) {
 	c := initClient(t)
+	ctx := context.Background()
 
 	user := randomUser(t, c)
-	_, err := c.MuteUser(context.Background(), randomUser(t, c).ID, user.ID)
+	_, err := c.MuteUser(ctx, randomUser(t, c).ID, user.ID)
 	require.NoError(t, err, "MuteUser should not return an error")
 
-	resp, err := c.QueryUsers(context.Background(), &QueryOption{
+	resp, err := c.QueryUsers(ctx, &QueryOption{
 		Filter: map[string]interface{}{
 			"id": map[string]string{"$eq": user.ID},
 		},
@@ -45,10 +46,10 @@ func TestClient_MuteUser(t *testing.T) {
 
 	user = randomUser(t, c)
 	// when timeout is given, expiration field should be set on mute
-	_, err = c.MuteUser(context.Background(), randomUser(t, c).ID, user.ID, MuteWithExpiration(60))
+	_, err = c.MuteUser(ctx, randomUser(t, c).ID, user.ID, MuteWithExpiration(60))
 	require.NoError(t, err, "MuteUser should not return an error")
 
-	resp, err = c.QueryUsers(context.Background(), &QueryOption{
+	resp, err = c.QueryUsers(ctx, &QueryOption{
 		Filter: map[string]interface{}{
 			"id": map[string]string{"$eq": user.ID},
 		},
@@ -67,14 +68,15 @@ func TestClient_MuteUser(t *testing.T) {
 
 func TestClient_MuteUsers(t *testing.T) {
 	c := initClient(t)
+	ctx := context.Background()
 
 	user := randomUser(t, c)
 	targetIDs := randomUsersID(t, c, 2)
 
-	_, err := c.MuteUsers(context.Background(), targetIDs, user.ID, MuteWithExpiration(60))
+	_, err := c.MuteUsers(ctx, targetIDs, user.ID, MuteWithExpiration(60))
 	require.NoError(t, err, "MuteUsers should not return an error")
 
-	resp, err := c.QueryUsers(context.Background(), &QueryOption{
+	resp, err := c.QueryUsers(ctx, &QueryOption{
 		Filter: map[string]interface{}{
 			"id": map[string]string{"$eq": user.ID},
 		},
@@ -92,13 +94,14 @@ func TestClient_MuteUsers(t *testing.T) {
 
 func TestClient_UnmuteUser(t *testing.T) {
 	c := initClient(t)
-
+	ctx := context.Background()
 	user := randomUser(t, c)
 	mutedUser := randomUser(t, c)
-	_, err := c.MuteUser(context.Background(), mutedUser.ID, user.ID)
+
+	_, err := c.MuteUser(ctx, mutedUser.ID, user.ID)
 	require.NoError(t, err, "MuteUser should not return an error")
 
-	_, err = c.UnmuteUser(context.Background(), mutedUser.ID, user.ID)
+	_, err = c.UnmuteUser(ctx, mutedUser.ID, user.ID)
 	assert.NoError(t, err)
 }
 
@@ -118,22 +121,24 @@ func TestClient_CreateGuestUser(t *testing.T) {
 
 func TestClient_UnmuteUsers(t *testing.T) {
 	c := initClient(t)
-
+	ctx := context.Background()
 	user := randomUser(t, c)
+
 	targetIDs := []string{randomUser(t, c).ID, randomUser(t, c).ID}
-	_, err := c.MuteUsers(context.Background(), targetIDs, user.ID)
+	_, err := c.MuteUsers(ctx, targetIDs, user.ID)
 	require.NoError(t, err, "MuteUsers should not return an error")
 
-	_, err = c.UnmuteUsers(context.Background(), targetIDs, user.ID)
+	_, err = c.UnmuteUsers(ctx, targetIDs, user.ID)
 	assert.NoError(t, err, "unmute users")
 }
 
 func TestClient_UpsertUsers(t *testing.T) {
 	c := initClient(t)
+	ctx := context.Background()
 
 	user := &User{ID: randomString(10)}
 
-	resp, err := c.UpsertUsers(context.Background(), user)
+	resp, err := c.UpsertUsers(ctx, user)
 	require.NoError(t, err, "update users")
 
 	assert.Contains(t, resp.Users, user.ID)
@@ -143,7 +148,7 @@ func TestClient_UpsertUsers(t *testing.T) {
 
 func TestClient_PartialUpdateUsers(t *testing.T) {
 	c := initClient(t)
-
+	ctx := context.Background()
 	user := randomUser(t, c)
 
 	update := PartialUserUpdate{
@@ -155,7 +160,7 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 		},
 	}
 
-	resp, err := c.PartialUpdateUsers(context.Background(), []PartialUserUpdate{update})
+	resp, err := c.PartialUpdateUsers(ctx, []PartialUserUpdate{update})
 	require.NoError(t, err, "partial update user")
 
 	got := resp.Users
@@ -171,7 +176,7 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 		Unset: []string{"test.passed"},
 	}
 
-	resp, err = c.PartialUpdateUsers(context.Background(), []PartialUserUpdate{update})
+	resp, err = c.PartialUpdateUsers(ctx, []PartialUserUpdate{update})
 	require.NoError(t, err, "partial update user")
 
 	got = resp.Users
@@ -182,8 +187,9 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 
 func ExampleClient_UpsertUser() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
-	_, err := client.UpsertUser(context.Background(), &User{
+	_, err := client.UpsertUser(ctx, &User{
 		ID:   "tommaso",
 		Name: "Tommaso",
 		Role: "Admin",
@@ -195,33 +201,38 @@ func ExampleClient_UpsertUser() {
 
 func ExampleClient_ExportUser() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
-	user, _ := client.ExportUser(context.Background(), "userID")
+	user, _ := client.ExportUser(ctx, "userID")
 	log.Printf("%#v", user)
 }
 
 func ExampleClient_DeactivateUser() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
-	_, _ = client.DeactivateUser(context.Background(), "userID")
+	_, _ = client.DeactivateUser(ctx, "userID")
 }
 
 func ExampleClient_ReactivateUser() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
-	_, _ = client.ReactivateUser(context.Background(), "userID")
+	_, _ = client.ReactivateUser(ctx, "userID")
 }
 
 func ExampleClient_DeleteUser() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
-	_, _ = client.DeleteUser(context.Background(), "userID")
+	_, _ = client.DeleteUser(ctx, "userID")
 }
 
 func ExampleClient_DeleteUser_hard() {
 	client, _ := NewClient("XXXX", "XXXX")
+	ctx := context.Background()
 
-	_, _ = client.DeleteUser(context.Background(), "userID",
+	_, _ = client.DeleteUser(ctx, "userID",
 		DeleteUserWithHardDelete(),
 		DeleteUserWithMarkMessagesDeleted(),
 	)


### PR DESCRIPTION
- Declare context once
- Introduce `t.Cleanup()` everywhere