### PR TITLE
refactor(app): add SetEnforceUniqueUsernames to restrict allowed values

### DIFF
--- a/app.go
+++ b/app.go
@@ -54,6 +54,36 @@ type AppSettings struct {
 	AsyncModerationConfig     *AsyncModerationConfiguration `json:"async_moderation_config,omitempty"`
 }
 
+type EnforceUniqueUsernames int64
+
+const (
+	No EnforceUniqueUsernames = iota
+	App
+	Team
+)
+
+// check allowed values for enforce_unique_usernames here
+// https://getstream.io/chat/docs/rest/#settings-updateapp
+func (s EnforceUniqueUsernames) String() *string {
+	var result string
+	switch s {
+	case No:
+		result = "no"
+	case App:
+		result = "app"
+	case Team:
+		result = "team"
+	default:
+		result = "app"
+	}
+	return &result
+}
+
+func (a *AppSettings) SetEnforceUniqueUsernames(e EnforceUniqueUsernames) *AppSettings {
+	a.EnforceUniqueUsernames = e.String()
+	return a
+}
+
 func (a *AppSettings) SetDisableAuth(b bool) *AppSettings {
 	a.DisableAuth = &b
 	return a


### PR DESCRIPTION
## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] The code changes follow best practices
- [X] Code changes are tested (add some information if not applicable)

## Description of the pull request

Since I couldn't find the allowed values in the GO SDK docs, I decided to add the SetEnforceUniqueUsernames function, because it restricts the allowed values and shows the developer which values are allowed. If neccessary I could write a test