### PR TITLE
fix: include push providers in push notification fields

### DIFF
--- a/app.go
+++ b/app.go
@@ -134,6 +134,7 @@ type PushNotificationFields struct {
 	FirebaseConfig FirebaseConfig `json:"firebase"`
 	HuaweiConfig   HuaweiConfig   `json:"huawei"`
 	XiaomiConfig   XiaomiConfig   `json:"xiaomi"`
+	Providers      []PushProvider `json:"providers,omitempty"`
 }
 
 type FirebaseConfigRequest struct {


### PR DESCRIPTION
# Submit a pull request
The response includes `providers` which was not included in the struct.

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
