### PR TITLE
feat: Add a new exported setter for the auth token field

### DIFF
--- a/client.go
+++ b/client.go
@@ -106,6 +106,11 @@ func NewClient(apiKey, apiSecret string, options ...ClientOption) (*Client, erro
 	return client, nil
 }
 
+// SetToken sets the auth token.
+func (c *Client) SetToken(token string) {
+	c.authToken = token
+}
+
 // SetClient sets a new underlying HTTP client.
 func (c *Client) SetClient(client *http.Client) {
 	c.HTTP = client


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

The NewClient method creates a server token and with that token, the messages won't get moderated. With this change, the CreateToken method can be called with the sender user and that token can be set to the client. This way the messages will be moderated.
