### PR TITLE
Replace assert pkg with the require pkg

### DIFF
--- a/channel_test.go
+++ b/channel_test.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,11 +55,11 @@ func TestClient_CreateChannel(t *testing.T) {
 		require.NoError(t, err, "create channel", ch)
 
 		channel := resp.Channel
-		assert.Equal(t, c, channel.client, "client link")
-		assert.Equal(t, ch.Type, channel.Type, "channel type")
-		assert.Equal(t, ch.ID, channel.ID, "channel id")
-		assert.Equal(t, ch.MemberCount, channel.MemberCount, "member count")
-		assert.Len(t, channel.Members, ch.MemberCount, "members length")
+		require.Equal(t, c, channel.client, "client link")
+		require.Equal(t, ch.Type, channel.Type, "channel type")
+		require.Equal(t, ch.ID, channel.ID, "channel id")
+		require.Equal(t, ch.MemberCount, channel.MemberCount, "member count")
+		require.Len(t, channel.Members, ch.MemberCount, "members length")
 	})
 
 	tests := []struct {
@@ -98,13 +97,13 @@ func TestClient_CreateChannel(t *testing.T) {
 			require.NoError(t, err, "create channel", tt)
 
 			channel := resp.Channel
-			assert.Equal(t, tt.channelType, channel.Type, "channel type")
-			assert.NotEmpty(t, channel.ID)
+			require.Equal(t, tt.channelType, channel.Type, "channel type")
+			require.NotEmpty(t, channel.ID)
 			if tt.id != "" {
-				assert.Equal(t, tt.id, channel.ID, "channel id")
+				require.Equal(t, tt.id, channel.ID, "channel id")
 			}
 
-			assert.Equal(t, tt.userID, channel.CreatedBy.ID, "channel created by")
+			require.Equal(t, tt.userID, channel.CreatedBy.ID, "channel created by")
 		})
 	}
 }
@@ -134,7 +133,7 @@ func TestChannel_AddMembers(t *testing.T) {
 	require.NoError(t, err, "create channel")
 	ch := resp.Channel
 
-	assert.Empty(t, ch.Members, "members are empty")
+	require.Empty(t, ch.Members, "members are empty")
 
 	user := randomUser(t, c)
 
@@ -148,7 +147,7 @@ func TestChannel_AddMembers(t *testing.T) {
 
 	// refresh channel state
 	require.NoError(t, ch.refresh(ctx), "refresh channel")
-	assert.Equal(t, user.ID, ch.Members[0].User.ID, "members contain user id")
+	require.Equal(t, user.ID, ch.Members[0].User.ID, "members contain user id")
 }
 
 func TestChannel_AssignRoles(t *testing.T) {
@@ -177,7 +176,7 @@ func TestChannel_QueryMembers(t *testing.T) {
 	require.NoError(t, err, "create channel")
 	ch := resp1.Channel
 
-	assert.Empty(t, ch.Members, "members are empty")
+	require.Empty(t, ch.Members, "members are empty")
 
 	prefix := randomString(12)
 	names := []string{"paul", "george", "john", "jessica", "john2"}
@@ -225,7 +224,7 @@ func TestChannel_InviteMembers(t *testing.T) {
 	require.NoError(t, err, "create channel")
 	ch := resp.Channel
 
-	assert.Empty(t, ch.Members, "members are empty")
+	require.Empty(t, ch.Members, "members are empty")
 
 	user := randomUser(t, c)
 
@@ -235,10 +234,10 @@ func TestChannel_InviteMembers(t *testing.T) {
 	// refresh channel state
 	require.NoError(t, ch.refresh(ctx), "refresh channel")
 
-	assert.Equal(t, user.ID, ch.Members[0].User.ID, "members contain user id")
-	assert.True(t, ch.Members[0].Invited, "member is invited")
-	assert.Nil(t, ch.Members[0].InviteAcceptedAt, "invite is not accepted")
-	assert.Nil(t, ch.Members[0].InviteRejectedAt, "invite is not rejected")
+	require.Equal(t, user.ID, ch.Members[0].User.ID, "members contain user id")
+	require.True(t, ch.Members[0].Invited, "member is invited")
+	require.Nil(t, ch.Members[0].InviteAcceptedAt, "invite is not accepted")
+	require.Nil(t, ch.Members[0].InviteRejectedAt, "invite is not rejected")
 }
 
 func TestChannel_Moderation(t *testing.T) {
@@ -251,7 +250,7 @@ func TestChannel_Moderation(t *testing.T) {
 	require.NoError(t, err, "create channel")
 	ch := resp.Channel
 
-	assert.Empty(t, ch.Members, "members are empty")
+	require.Empty(t, ch.Members, "members are empty")
 
 	user := randomUser(t, c)
 
@@ -265,8 +264,8 @@ func TestChannel_Moderation(t *testing.T) {
 	// refresh channel state
 	require.NoError(t, ch.refresh(ctx), "refresh channel")
 
-	assert.Equal(t, user.ID, ch.Members[0].User.ID, "user exists")
-	assert.Equal(t, "moderator", ch.Members[0].Role, "user role is moderator")
+	require.Equal(t, user.ID, ch.Members[0].User.ID, "user exists")
+	require.Equal(t, "moderator", ch.Members[0].Role, "user role is moderator")
 
 	_, err = ch.DemoteModerators(ctx, user.ID)
 	require.NoError(t, err, "demote moderators")
@@ -274,8 +273,8 @@ func TestChannel_Moderation(t *testing.T) {
 	// refresh channel state
 	require.NoError(t, ch.refresh(ctx), "refresh channel")
 
-	assert.Equal(t, user.ID, ch.Members[0].User.ID, "user exists")
-	assert.Equal(t, "member", ch.Members[0].Role, "user role is member")
+	require.Equal(t, user.ID, ch.Members[0].User.ID, "user exists")
+	require.Equal(t, "member", ch.Members[0].Role, "user role is member")
 }
 
 func TestChannel_Delete(t *testing.T) {
@@ -305,7 +304,7 @@ func TestChannel_GetReplies(t *testing.T) {
 
 	repliesResp, err := ch.GetReplies(ctx, msg.ID, nil)
 	require.NoError(t, err, "get replies")
-	assert.Len(t, repliesResp.Messages, 1)
+	require.Len(t, repliesResp.Messages, 1)
 }
 
 func TestChannel_RemoveMembers(t *testing.T) {
@@ -322,7 +321,7 @@ func TestChannel_RemoveMembers(t *testing.T) {
 	require.NoError(t, err, "remove members")
 
 	for _, member := range ch.Members {
-		assert.NotEqual(t, member.User.ID, user.ID, "member is not present")
+		require.NotEqual(t, member.User.ID, user.ID, "member is not present")
 	}
 }
 
@@ -358,8 +357,8 @@ func TestChannel_SendMessage(t *testing.T) {
 
 	// check that message was updated
 	msg = resp.Message
-	assert.NotEmpty(t, msg.ID, "message has ID")
-	assert.NotEmpty(t, msg.HTML, "message has HTML body")
+	require.NotEmpty(t, msg.ID, "message has ID")
+	require.NotEmpty(t, msg.HTML, "message has HTML body")
 
 	msg2 := &Message{
 		Text:   "text message 2",
@@ -371,9 +370,9 @@ func TestChannel_SendMessage(t *testing.T) {
 
 	// check that message was updated
 	msg2 = resp.Message
-	assert.NotEmpty(t, msg2.ID, "message has ID")
-	assert.NotEmpty(t, msg2.HTML, "message has HTML body")
-	assert.True(t, msg2.Silent, "message silent flag is set")
+	require.NotEmpty(t, msg2.ID, "message has ID")
+	require.NotEmpty(t, msg2.HTML, "message has HTML body")
+	require.True(t, msg2.Silent, "message silent flag is set")
 }
 
 func TestChannel_SendSystemMessage(t *testing.T) {
@@ -391,8 +390,8 @@ func TestChannel_SendSystemMessage(t *testing.T) {
 
 	// check that message was updated
 	msg = resp.Message
-	assert.NotEmpty(t, msg.ID, "message has ID")
-	assert.Equal(t, MessageTypeSystem, msg.Type, "message type is system")
+	require.NotEmpty(t, msg.ID, "message has ID")
+	require.Equal(t, MessageTypeSystem, msg.Type, "message type is system")
 }
 
 func TestChannel_Truncate(t *testing.T) {
@@ -410,13 +409,13 @@ func TestChannel_Truncate(t *testing.T) {
 	resp, err := ch.SendMessage(ctx, msg, user.ID)
 	require.NoError(t, err, "send message")
 	require.NoError(t, ch.refresh(ctx), "refresh channel")
-	assert.Equal(t, ch.Messages[0].ID, resp.Message.ID, "message exists")
+	require.Equal(t, ch.Messages[0].ID, resp.Message.ID, "message exists")
 
 	// Now truncate it
 	_, err = ch.Truncate(ctx)
 	require.NoError(t, err, "truncate channel")
 	require.NoError(t, ch.refresh(ctx), "refresh channel")
-	assert.Empty(t, ch.Messages, "channel is empty")
+	require.Empty(t, ch.Messages, "channel is empty")
 }
 
 func TestChannel_TruncateWithOptions(t *testing.T) {
@@ -434,7 +433,7 @@ func TestChannel_TruncateWithOptions(t *testing.T) {
 	resp, err := ch.SendMessage(ctx, msg, user.ID)
 	require.NoError(t, err, "send message")
 	require.NoError(t, ch.refresh(ctx), "refresh channel")
-	assert.Equal(t, ch.Messages[0].ID, resp.Message.ID, "message exists")
+	require.Equal(t, ch.Messages[0].ID, resp.Message.ID, "message exists")
 
 	// Now truncate it
 	_, err = ch.Truncate(ctx,

--- a/channel_type_test.go
+++ b/channel_type_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,10 +39,10 @@ func TestClient_GetChannelType(t *testing.T) {
 	resp, err := c.GetChannelType(ctx, ct.Name)
 	require.NoError(t, err, "get channel type")
 
-	assert.Equal(t, ct.Name, resp.ChannelType.Name)
-	assert.Equal(t, len(ct.Commands), len(resp.ChannelType.Commands))
-	assert.Equal(t, ct.Permissions, resp.ChannelType.Permissions)
-	assert.NotEmpty(t, resp.Grants)
+	require.Equal(t, ct.Name, resp.ChannelType.Name)
+	require.Equal(t, len(ct.Commands), len(resp.ChannelType.Commands))
+	require.Equal(t, ct.Permissions, resp.ChannelType.Permissions)
+	require.NotEmpty(t, resp.Grants)
 }
 
 func TestClient_ListChannelTypes(t *testing.T) {
@@ -54,7 +53,7 @@ func TestClient_ListChannelTypes(t *testing.T) {
 	resp, err := c.ListChannelTypes(ctx)
 	require.NoError(t, err, "list channel types")
 
-	assert.Contains(t, resp.ChannelTypes, ct.Name)
+	require.Contains(t, resp.ChannelTypes, ct.Name)
 }
 
 func TestClient_UpdateChannelTypeMarkMessagesPending(t *testing.T) {

--- a/command_test.go
+++ b/command_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,8 +34,8 @@ func TestClient_GetCommand(t *testing.T) {
 	resp, err := c.GetCommand(ctx, cmd.Name)
 	require.NoError(t, err, "get command")
 
-	assert.Equal(t, cmd.Name, resp.Command.Name)
-	assert.Equal(t, cmd.Description, resp.Command.Description)
+	require.Equal(t, cmd.Name, resp.Command.Name)
+	require.Equal(t, cmd.Description, resp.Command.Description)
 }
 
 func TestClient_ListCommands(t *testing.T) {
@@ -47,7 +46,7 @@ func TestClient_ListCommands(t *testing.T) {
 	resp, err := c.ListCommands(ctx)
 	require.NoError(t, err, "list commands")
 
-	assert.Contains(t, resp.Commands, cmd)
+	require.Contains(t, resp.Commands, cmd)
 }
 
 func TestClient_UpdateCommand(t *testing.T) {
@@ -59,8 +58,8 @@ func TestClient_UpdateCommand(t *testing.T) {
 	resp, err := c.UpdateCommand(ctx, cmd.Name, &update)
 	require.NoError(t, err, "update command")
 
-	assert.Equal(t, cmd.Name, resp.Command.Name)
-	assert.Equal(t, "new description", resp.Command.Description)
+	require.Equal(t, cmd.Name, resp.Command.Name)
+	require.Equal(t, "new description", resp.Command.Description)
 }
 
 // See https://getstream.io/chat/docs/custom_commands/ for more details.

--- a/device_test.go
+++ b/device_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +13,7 @@ func TestClient_Devices(t *testing.T) {
 	user := randomUser(t, c)
 
 	devices := []*Device{
-		{UserID: user.ID, ID: randomString(12), PushProvider: PushProviderFirebase},
+		{UserID: user.ID, ID: "xxxx", PushProvider: PushProviderFirebase},
 		{UserID: user.ID, ID: randomString(12), PushProvider: PushProviderAPNS},
 	}
 
@@ -25,7 +24,7 @@ func TestClient_Devices(t *testing.T) {
 		resp, err := c.GetDevices(ctx, user.ID)
 		require.NoError(t, err, "get devices")
 
-		assert.True(t, deviceIDExists(resp.Devices, dev.ID), "device with ID %s was created", dev.ID)
+		require.True(t, deviceIDExists(resp.Devices, dev.ID), "device with ID %s was created", dev.ID)
 		_, err = c.DeleteDevice(ctx, user.ID, dev.ID)
 		require.NoError(t, err, "delete device")
 	}

--- a/event_test.go
+++ b/event_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +38,7 @@ func TestEventSupportsAllFields(t *testing.T) {
 			t.Errorf("Error unmarshaling %q: %v", name, err)
 		}
 
-		assert.Equal(t, name, result.Type)
+		require.Equal(t, name, result.Type)
 	}
 }
 

--- a/message_history_test.go
+++ b/message_history_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,12 +28,12 @@ func TestMessageHistory(t *testing.T) {
 	updatedCustomFieldValue := "updated custom value"
 	// update the message by user1
 	_, err = client.UpdateMessage(ctx, &Message{Text: updatedText1, ExtraData: map[string]interface{}{customField: updatedCustomFieldValue}, UserID: user1.ID}, message.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	updatedText2 := "updated text 2"
 	// update the message by user2
 	_, err = client.UpdateMessage(ctx, &Message{Text: updatedText2, UserID: user2.ID}, message.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("test query", func(t *testing.T) {
 		req := QueryMessageHistoryRequest{
@@ -43,21 +42,21 @@ func TestMessageHistory(t *testing.T) {
 			},
 		}
 		messageHistoryResponse, err := client.QueryMessageHistory(ctx, req)
-		assert.NoError(t, err)
-		assert.NotNil(t, messageHistoryResponse)
+		require.NoError(t, err)
+		require.NotNil(t, messageHistoryResponse)
 
 		history := messageHistoryResponse.MessageHistory
-		assert.Equal(t, 2, len(history))
+		require.Equal(t, 2, len(history))
 
 		firstUpdate := history[1]
-		assert.Equal(t, initialText, firstUpdate.Text)
-		assert.Equal(t, user1.ID, firstUpdate.MessageUpdatedByID)
-		assert.Equal(t, initialCustomFieldValue, firstUpdate.ExtraData[customField].(string))
+		require.Equal(t, initialText, firstUpdate.Text)
+		require.Equal(t, user1.ID, firstUpdate.MessageUpdatedByID)
+		require.Equal(t, initialCustomFieldValue, firstUpdate.ExtraData[customField].(string))
 
 		secondUpdate := history[0]
-		assert.Equal(t, updatedText1, secondUpdate.Text)
-		assert.Equal(t, user2.ID, secondUpdate.MessageUpdatedByID)
-		assert.Equal(t, updatedCustomFieldValue, secondUpdate.ExtraData[customField].(string))
+		require.Equal(t, updatedText1, secondUpdate.Text)
+		require.Equal(t, user2.ID, secondUpdate.MessageUpdatedByID)
+		require.Equal(t, updatedCustomFieldValue, secondUpdate.ExtraData[customField].(string))
 	})
 
 	t.Run("test sorting", func(t *testing.T) {
@@ -73,18 +72,18 @@ func TestMessageHistory(t *testing.T) {
 			},
 		}
 		sortedHistoryResponse, err := client.QueryMessageHistory(ctx, sortedHistoryQueryRequest)
-		assert.NoError(t, err)
-		assert.NotNil(t, sortedHistoryResponse)
+		require.NoError(t, err)
+		require.NotNil(t, sortedHistoryResponse)
 
 		sortedHistory := sortedHistoryResponse.MessageHistory
-		assert.Equal(t, 2, len(sortedHistory))
+		require.Equal(t, 2, len(sortedHistory))
 
 		firstUpdate := sortedHistory[0]
-		assert.Equal(t, initialText, firstUpdate.Text)
-		assert.Equal(t, user1.ID, firstUpdate.MessageUpdatedByID)
+		require.Equal(t, initialText, firstUpdate.Text)
+		require.Equal(t, user1.ID, firstUpdate.MessageUpdatedByID)
 
 		secondUpdate := sortedHistory[1]
-		assert.Equal(t, updatedText1, secondUpdate.Text)
-		assert.Equal(t, user2.ID, secondUpdate.MessageUpdatedByID)
+		require.Equal(t, updatedText1, secondUpdate.Text)
+		require.Equal(t, user2.ID, secondUpdate.MessageUpdatedByID)
 	})
 }

--- a/permission_client_test.go
+++ b/permission_client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +23,7 @@ func TestPermissions_RoleEndpoints(t *testing.T) {
 
 	roles, err := p.ListRoles(ctx)
 	require.NoError(t, err)
-	assert.NotEmpty(t, roles)
+	require.NotEmpty(t, roles)
 
 	t.Cleanup(func() {
 		resp, _ := p.ListRoles(ctx)
@@ -55,15 +54,15 @@ func TestPermissions_PermissionEndpoints(t *testing.T) {
 
 	perms, err := p.ListPermissions(ctx)
 	require.NoError(t, err)
-	assert.NotEmpty(t, perms)
+	require.NotEmpty(t, perms)
 
 	resp, err := p.GetPermission(ctx, "create-channel")
 	require.NoError(t, err)
 
 	perm := resp.Permission
-	assert.Equal(t, "create-channel", perm.ID)
-	assert.False(t, perm.Custom)
-	assert.Empty(t, perm.Condition)
+	require.Equal(t, "create-channel", perm.ID)
+	require.False(t, perm.Custom)
+	require.Empty(t, perm.Condition)
 
 	t.Cleanup(func() {
 		resp, _ := p.ListPermissions(ctx)

--- a/query_test.go
+++ b/query_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -119,7 +118,7 @@ func TestClient_Search(t *testing.T) {
 
 		require.NoError(tt, err)
 
-		assert.Len(tt, resp.Messages, 2)
+		require.Len(tt, resp.Messages, 2)
 	})
 	t.Run("Message filters", func(tt *testing.T) {
 		resp, err := c.Search(ctx, SearchRequest{
@@ -136,7 +135,7 @@ func TestClient_Search(t *testing.T) {
 		})
 		require.NoError(tt, err)
 
-		assert.Len(tt, resp.Messages, 2)
+		require.Len(tt, resp.Messages, 2)
 	})
 	t.Run("Query and message filters error", func(tt *testing.T) {
 		_, err := c.Search(ctx, SearchRequest{
@@ -226,8 +225,8 @@ func TestClient_SearchWithFullResponse(t *testing.T) {
 
 	gotMessageIDs := make([]string, 0, 6)
 	require.NoError(t, err)
-	assert.NotEmpty(t, got.Next)
-	assert.Len(t, got.Results, 3)
+	require.NotEmpty(t, got.Next)
+	require.Len(t, got.Results, 3)
 	for _, result := range got.Results {
 		gotMessageIDs = append(gotMessageIDs, result.Message.ID)
 	}
@@ -242,13 +241,13 @@ func TestClient_SearchWithFullResponse(t *testing.T) {
 		Limit: 3,
 	})
 	require.NoError(t, err)
-	assert.NotEmpty(t, got.Previous)
-	assert.Empty(t, got.Next)
-	assert.Len(t, got.Results, 3)
+	require.NotEmpty(t, got.Previous)
+	require.Empty(t, got.Next)
+	require.Len(t, got.Results, 3)
 	for _, result := range got.Results {
 		gotMessageIDs = append(gotMessageIDs, result.Message.ID)
 	}
-	assert.Equal(t, messageIDs, gotMessageIDs)
+	require.Equal(t, messageIDs, gotMessageIDs)
 }
 
 func TestClient_QueryMessageFlags(t *testing.T) {
@@ -287,7 +286,7 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Len(t, got.Flags, 2)
+	require.Len(t, got.Flags, 2)
 
 	// one flag shows up in this query by user_id
 	got, err = c.QueryMessageFlags(ctx, &QueryOption{
@@ -296,7 +295,7 @@ func TestClient_QueryMessageFlags(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Len(t, got.Flags, 1)
+	require.Len(t, got.Flags, 1)
 }
 
 func TestClient_QueryFlagReportsAndReview(t *testing.T) {

--- a/reaction_test.go
+++ b/reaction_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,9 +41,9 @@ func TestChannel_SendReaction(t *testing.T) {
 	reactionResp, err := c.SendReaction(ctx, &reaction, resp.Message.ID, user.ID)
 	require.NoError(t, err, "send reaction")
 
-	assert.Equal(t, 1, reactionResp.Message.ReactionCounts[reaction.Type], "reaction count", reaction)
+	require.Equal(t, 1, reactionResp.Message.ReactionCounts[reaction.Type], "reaction count", reaction)
 
-	assert.Condition(t, reactionExistsCondition(reactionResp.Message.LatestReactions, reaction.Type), "latest reaction exists")
+	require.Condition(t, reactionExistsCondition(reactionResp.Message.LatestReactions, reaction.Type), "latest reaction exists")
 }
 
 func reactionExistsCondition(reactions []*Reaction, searchType string) func() bool {
@@ -78,8 +77,8 @@ func TestClient_DeleteReaction(t *testing.T) {
 	reactionResp, err = c.DeleteReaction(ctx, reactionResp.Message.ID, reaction.Type, user.ID)
 	require.NoError(t, err, "delete reaction")
 
-	assert.Equal(t, 0, reactionResp.Message.ReactionCounts[reaction.Type], "reaction count")
-	assert.Empty(t, reactionResp.Message.LatestReactions, "latest reactions empty")
+	require.Equal(t, 0, reactionResp.Message.ReactionCounts[reaction.Type], "reaction count")
+	require.Empty(t, reactionResp.Message.LatestReactions, "latest reactions empty")
 }
 
 func TestClient_GetReactions(t *testing.T) {
@@ -98,7 +97,7 @@ func TestClient_GetReactions(t *testing.T) {
 
 	reactionsResp, err := c.GetReactions(ctx, msg.ID, nil)
 	require.NoError(t, err, "get reactions")
-	assert.Empty(t, reactionsResp.Reactions, "reactions empty")
+	require.Empty(t, reactionsResp.Reactions, "reactions empty")
 
 	reaction := Reaction{Type: "love"}
 
@@ -108,5 +107,5 @@ func TestClient_GetReactions(t *testing.T) {
 	reactionsResp, err = c.GetReactions(ctx, reactionResp.Message.ID, nil)
 	require.NoError(t, err, "get reactions")
 
-	assert.Condition(t, reactionExistsCondition(reactionsResp.Reactions, reaction.Type), "reaction exists")
+	require.Condition(t, reactionExistsCondition(reactionsResp.Reactions, reaction.Type), "reaction exists")
 }

--- a/user_test.go
+++ b/user_test.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,9 +28,9 @@ func TestClient_MuteUser(t *testing.T) {
 	require.NotEmptyf(t, users[0].Mutes, "user should have Mutes: %+v", users[0])
 
 	mute := users[0].Mutes[0]
-	assert.NotEmpty(t, mute.User, "mute should have a User")
-	assert.NotEmpty(t, mute.Target, "mute should have a Target")
-	assert.Empty(t, mute.Expires, "mute should have no Expires")
+	require.NotEmpty(t, mute.User, "mute should have a User")
+	require.NotEmpty(t, mute.Target, "mute should have a Target")
+	require.Empty(t, mute.Expires, "mute should have no Expires")
 
 	user = randomUser(t, c)
 	// when timeout is given, expiration field should be set on mute
@@ -50,9 +49,9 @@ func TestClient_MuteUser(t *testing.T) {
 	require.NotEmptyf(t, users[0].Mutes, "user should have Mutes: %+v", users[0])
 
 	mute = users[0].Mutes[0]
-	assert.NotEmpty(t, mute.User, "mute should have a User")
-	assert.NotEmpty(t, mute.Target, "mute should have a Target")
-	assert.NotEmpty(t, mute.Expires, "mute should have Expires")
+	require.NotEmpty(t, mute.User, "mute should have a User")
+	require.NotEmpty(t, mute.Target, "mute should have a Target")
+	require.NotEmpty(t, mute.Expires, "mute should have Expires")
 }
 
 func TestClient_MuteUsers(t *testing.T) {
@@ -77,7 +76,7 @@ func TestClient_MuteUsers(t *testing.T) {
 	require.NotEmptyf(t, users[0].Mutes, "user should have Mutes: %+v", users[0])
 
 	for _, mute := range users[0].Mutes {
-		assert.NotEmpty(t, mute.Expires, "mute should have Expires")
+		require.NotEmpty(t, mute.Expires, "mute should have Expires")
 	}
 }
 func TestClient_BlockUsers(t *testing.T) {
@@ -154,7 +153,7 @@ func TestClient_UnmuteUser(t *testing.T) {
 	require.NoError(t, err, "MuteUser should not return an error")
 
 	_, err = c.UnmuteUser(ctx, mutedUser.ID, user.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestClient_CreateGuestUser(t *testing.T) {
@@ -181,7 +180,7 @@ func TestClient_UnmuteUsers(t *testing.T) {
 	require.NoError(t, err, "MuteUsers should not return an error")
 
 	_, err = c.UnmuteUsers(ctx, targetIDs, user.ID)
-	assert.NoError(t, err, "unmute users")
+	require.NoError(t, err, "unmute users")
 }
 
 func TestClient_UpsertUsers(t *testing.T) {
@@ -193,9 +192,9 @@ func TestClient_UpsertUsers(t *testing.T) {
 	resp, err := c.UpsertUsers(ctx, user)
 	require.NoError(t, err, "update users")
 
-	assert.Contains(t, resp.Users, user.ID)
-	assert.NotEmpty(t, resp.Users[user.ID].CreatedAt)
-	assert.NotEmpty(t, resp.Users[user.ID].UpdatedAt)
+	require.Contains(t, resp.Users, user.ID)
+	require.NotEmpty(t, resp.Users[user.ID].CreatedAt)
+	require.NotEmpty(t, resp.Users[user.ID].UpdatedAt)
 }
 
 func TestClient_PartialUpdateUsers(t *testing.T) {
@@ -216,9 +215,9 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 	require.NoError(t, err, "partial update user")
 
 	got := resp.Users
-	assert.Contains(t, got, user.ID)
-	assert.Contains(t, got[user.ID].ExtraData, "test", "extra data contains: %v", got[user.ID].ExtraData)
-	assert.Equal(t, map[string]interface{}{"passed": true}, got[user.ID].ExtraData["test"])
+	require.Contains(t, got, user.ID)
+	require.Contains(t, got[user.ID].ExtraData, "test", "extra data contains: %v", got[user.ID].ExtraData)
+	require.Equal(t, map[string]interface{}{"passed": true}, got[user.ID].ExtraData["test"])
 
 	update = PartialUserUpdate{
 		ID:    user.ID,
@@ -229,9 +228,9 @@ func TestClient_PartialUpdateUsers(t *testing.T) {
 	require.NoError(t, err, "partial update user")
 
 	got = resp.Users
-	assert.Contains(t, got, user.ID)
-	assert.Contains(t, got[user.ID].ExtraData, "test", "extra data contains", got[user.ID].ExtraData)
-	assert.Empty(t, got[user.ID].ExtraData["test"], "extra data field removed")
+	require.Contains(t, got, user.ID)
+	require.Contains(t, got[user.ID].ExtraData, "test", "extra data contains", got[user.ID].ExtraData)
+	require.Empty(t, got[user.ID].ExtraData["test"], "extra data field removed")
 }
 
 func ExampleClient_UpsertUser() {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Use assert package ([github.com/stretchr/testify/assert](https://pkg.go.dev/github.com/stretchr/testify@v1.7.0/assert)) whose tests outputs are dependent of each other, creates a situation where all tests crash if one of the dependent test output fails.

With require package([github.com/stretchr/testify/require](https://pkg.go.dev/github.com/stretchr/testify@v1.7.0/require)) test fail gracefully without affecting other unrelated tests.

Its is also highlighted in the documentation: https://pkg.go.dev/github.com/stretchr/testify@v1.7.0/require#hdr-Assertions

>The `require` package have same global functions as in the `assert` package, but instead of returning a boolean result they call `t.FailNow()`.
