### PR TITLE
feat: add support for querying deactivated users

### DIFF
--- a/query.go
+++ b/query.go
@@ -32,11 +32,12 @@ type queryRequest struct {
 	State    bool `json:"state"`
 	Presence bool `json:"presence"`
 
-	UserID       string `json:"user_id,omitempty"`
-	Limit        int    `json:"limit,omitempty"`
-	Offset       int    `json:"offset,omitempty"`
-	MemberLimit  *int   `json:"member_limit,omitempty"`
-	MessageLimit *int   `json:"message_limit,omitempty"`
+	UserID                  string `json:"user_id,omitempty"`
+	Limit                   int    `json:"limit,omitempty"`
+	Offset                  int    `json:"offset,omitempty"`
+	MemberLimit             *int   `json:"member_limit,omitempty"`
+	MessageLimit            *int   `json:"message_limit,omitempty"`
+	IncludeDeactivatedUsers bool   `json:"include_deactivated_users,omitempty"`
 
 	FilterConditions map[string]interface{} `json:"filter_conditions,omitempty"`
 	Sort             []*SortOption          `json:"sort,omitempty"`
@@ -58,19 +59,26 @@ type FlagReport struct {
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 
+type QueryUsersOptions struct {
+	QueryOption
+
+	IncludeDeactivatedUsers bool `json:"include_deactivated_users"`
+}
+
 type QueryUsersResponse struct {
 	Users []*User `json:"users"`
 	Response
 }
 
-// QueryUsers returns list of users that match QueryOption.
+// QueryUsers returns list of users that match QueryUsersOptions.
 // If any number of SortOption are set, result will be sorted by field and direction in the order of sort options.
-func (c *Client) QueryUsers(ctx context.Context, q *QueryOption, sorters ...*SortOption) (*QueryUsersResponse, error) {
+func (c *Client) QueryUsers(ctx context.Context, q *QueryUsersOptions, sorters ...*SortOption) (*QueryUsersResponse, error) {
 	qp := queryRequest{
-		FilterConditions: q.Filter,
-		Limit:            q.Limit,
-		Offset:           q.Offset,
-		Sort:             sorters,
+		FilterConditions:        q.Filter,
+		Limit:                   q.Limit,
+		Offset:                  q.Offset,
+		IncludeDeactivatedUsers: q.IncludeDeactivatedUsers,
+		Sort:                    sorters,
 	}
 
 	data, err := json.Marshal(&qp)

--- a/user_test.go
+++ b/user_test.go
@@ -17,9 +17,11 @@ func TestClient_MuteUser(t *testing.T) {
 	_, err := c.MuteUser(ctx, randomUser(t, c).ID, user.ID)
 	require.NoError(t, err, "MuteUser should not return an error")
 
-	resp, err := c.QueryUsers(ctx, &QueryOption{
-		Filter: map[string]interface{}{
-			"id": map[string]string{"$eq": user.ID},
+	resp, err := c.QueryUsers(ctx, &QueryUsersOptions{
+		QueryOption: QueryOption{
+			Filter: map[string]interface{}{
+				"id": map[string]string{"$eq": user.ID},
+			},
 		},
 	})
 
@@ -38,9 +40,11 @@ func TestClient_MuteUser(t *testing.T) {
 	_, err = c.MuteUser(ctx, randomUser(t, c).ID, user.ID, MuteWithExpiration(60))
 	require.NoError(t, err, "MuteUser should not return an error")
 
-	resp, err = c.QueryUsers(ctx, &QueryOption{
-		Filter: map[string]interface{}{
-			"id": map[string]string{"$eq": user.ID},
+	resp, err = c.QueryUsers(ctx, &QueryUsersOptions{
+		QueryOption: QueryOption{
+			Filter: map[string]interface{}{
+				"id": map[string]string{"$eq": user.ID},
+			},
 		},
 	})
 
@@ -65,9 +69,11 @@ func TestClient_MuteUsers(t *testing.T) {
 	_, err := c.MuteUsers(ctx, targetIDs, user.ID, MuteWithExpiration(60))
 	require.NoError(t, err, "MuteUsers should not return an error")
 
-	resp, err := c.QueryUsers(ctx, &QueryOption{
-		Filter: map[string]interface{}{
-			"id": map[string]string{"$eq": user.ID},
+	resp, err := c.QueryUsers(ctx, &QueryUsersOptions{
+		QueryOption: QueryOption{
+			Filter: map[string]interface{}{
+				"id": map[string]string{"$eq": user.ID},
+			},
 		},
 	})
 
@@ -80,6 +86,7 @@ func TestClient_MuteUsers(t *testing.T) {
 		assert.NotEmpty(t, mute.Expires, "mute should have Expires")
 	}
 }
+
 func TestClient_BlockUsers(t *testing.T) {
 	c := initClient(t)
 	ctx := context.Background()
@@ -90,9 +97,11 @@ func TestClient_BlockUsers(t *testing.T) {
 	_, err := c.BlockUser(ctx, blockedUser.ID, blockingUser.ID)
 	require.NoError(t, err, "BlockUser should not return an error")
 
-	resp, err := c.QueryUsers(ctx, &QueryOption{
-		Filter: map[string]interface{}{
-			"id": map[string]string{"$eq": blockingUser.ID},
+	resp, err := c.QueryUsers(ctx, &QueryUsersOptions{
+		QueryOption: QueryOption{
+			Filter: map[string]interface{}{
+				"id": map[string]string{"$eq": blockingUser.ID},
+			},
 		},
 	})
 
@@ -103,6 +112,7 @@ func TestClient_BlockUsers(t *testing.T) {
 
 	require.Equal(t, users[0].BlockedUserIDs[0], blockedUser.ID)
 }
+
 func TestClient_UnblockUsersGetBlockedUsers(t *testing.T) {
 	c := initClient(t)
 	ctx := context.Background()
@@ -113,9 +123,11 @@ func TestClient_UnblockUsersGetBlockedUsers(t *testing.T) {
 	_, err := c.BlockUser(ctx, blockedUser.ID, blockingUser.ID)
 	require.NoError(t, err, "BlockUser should not return an error")
 
-	resp, err := c.QueryUsers(ctx, &QueryOption{
-		Filter: map[string]interface{}{
-			"id": map[string]string{"$eq": blockingUser.ID},
+	resp, err := c.QueryUsers(ctx, &QueryUsersOptions{
+		QueryOption: QueryOption{
+			Filter: map[string]interface{}{
+				"id": map[string]string{"$eq": blockingUser.ID},
+			},
 		},
 	})
 
@@ -132,9 +144,11 @@ func TestClient_UnblockUsersGetBlockedUsers(t *testing.T) {
 	_, err = c.UnblockUser(ctx, blockedUser.ID, blockingUser.ID)
 	require.NoError(t, err, "UnblockUser should not return an error")
 
-	resp, err = c.QueryUsers(ctx, &QueryOption{
-		Filter: map[string]interface{}{
-			"id": map[string]string{"$eq": blockingUser.ID},
+	resp, err = c.QueryUsers(ctx, &QueryUsersOptions{
+		QueryOption: QueryOption{
+			Filter: map[string]interface{}{
+				"id": map[string]string{"$eq": blockingUser.ID},
+			},
 		},
 	})
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

This adds support for querying deactivated users.

Note: This is a breaking change since the signature of the `QueryUsers` methods had to change to accept a new type. The updated tests show how the signature must be updated