### PR TITLE
Adds MimeType to Attachment struct

### DIFF
--- a/message.go
+++ b/message.go
@@ -174,6 +174,7 @@ type Attachment struct {
 	ThumbURL    string `json:"thumb_url,omitempty"`
 	AssetURL    string `json:"asset_url,omitempty"`
 	OGScrapeURL string `json:"og_scrape_url,omitempty"`
+	MimeType    string `json:"mime_type,omitempty"`
 
 	ExtraData map[string]interface{} `json:"-"`
 }


### PR DESCRIPTION
It's present in the raw JSON, just not on this field

# Submit a pull request

## CLA

- [ X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ X] The code changes follow best practices
- [ X] Code changes are tested (add some information if not applicable)

## Description of the pull request

Adds the missing MimeType field to the Attachments struct. It's present in the returned JSON from the webhook.