### PR TITLE
[CHA-793] feat: Add pending and pinned messages to query channel response

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -94,6 +94,12 @@ type Channel struct {
 
 	ExtraData map[string]interface{} `json:"-"`
 
+	WatcherCount int     `json:"watcher_count"`
+	Watchers     []*User `json:"watchers"`
+
+	PushPreferences *ChannelPushPreferences `json:"push_preferences"`
+	Hidden          bool                    `json:"hidden"`
+
 	client *Client
 }
 

--- a/query.go
+++ b/query.go
@@ -100,17 +100,27 @@ type queryChannelResponse struct {
 }
 
 type queryChannelResponseData struct {
-	Channel         *Channel         `json:"channel"`
-	Messages        []*Message       `json:"messages"`
-	Read            []*ChannelRead   `json:"read"`
-	Members         []*ChannelMember `json:"members"`
-	PendingMessages []*Message       `json:"pending_messages"`
-	PinnedMessages  []*Message       `json:"pinned_messages"`
+	Channel         *Channel                `json:"channel"`
+	Messages        []*Message              `json:"messages"`
+	Read            []*ChannelRead          `json:"read"`
+	Members         []*ChannelMember        `json:"members"`
+	PendingMessages []*Message              `json:"pending_messages"`
+	PinnedMessages  []*Message              `json:"pinned_messages"`
+	Hidden          bool                    `json:"hidden"`
+	PushPreferences *ChannelPushPreferences `json:"push_preferences"`
+	WatcherCount    int                     `json:"watcher_count"`
+	Watchers        []*User                 `json:"watchers"`
 }
 
 type QueryChannelsResponse struct {
 	Channels []*Channel
 	Response
+}
+
+type ChannelPushPreferences struct {
+	ChatLevel     string     `json:"chat_level"`
+	CallLevel     string     `json:"call_level"`
+	DisabledUntil *time.Time `json:"disabled_until"`
 }
 
 // QueryChannels returns list of channels with members and messages, that match QueryOption.
@@ -139,6 +149,10 @@ func (c *Client) QueryChannels(ctx context.Context, q *QueryOption, sort ...*Sor
 		result[i].Messages = data.Messages
 		result[i].PendingMessages = data.PendingMessages
 		result[i].PinnedMessages = data.PinnedMessages
+		result[i].Hidden = data.Hidden
+		result[i].PushPreferences = data.PushPreferences
+		result[i].WatcherCount = data.WatcherCount
+		result[i].Watchers = data.Watchers
 		result[i].Read = data.Read
 		result[i].client = c
 	}

--- a/query.go
+++ b/query.go
@@ -100,10 +100,12 @@ type queryChannelResponse struct {
 }
 
 type queryChannelResponseData struct {
-	Channel  *Channel         `json:"channel"`
-	Messages []*Message       `json:"messages"`
-	Read     []*ChannelRead   `json:"read"`
-	Members  []*ChannelMember `json:"members"`
+	Channel         *Channel         `json:"channel"`
+	Messages        []*Message       `json:"messages"`
+	Read            []*ChannelRead   `json:"read"`
+	Members         []*ChannelMember `json:"members"`
+	PendingMessages []*Message       `json:"pending_messages"`
+	PinnedMessages  []*Message       `json:"pinned_messages"`
 }
 
 type QueryChannelsResponse struct {
@@ -135,6 +137,8 @@ func (c *Client) QueryChannels(ctx context.Context, q *QueryOption, sort ...*Sor
 		result[i] = data.Channel
 		result[i].Members = data.Members
 		result[i].Messages = data.Messages
+		result[i].PendingMessages = data.PendingMessages
+		result[i].PinnedMessages = data.PinnedMessages
 		result[i].Read = data.Read
 		result[i].client = c
 	}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request


From Js SDK

```typescript
export type ChannelAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
  channel: ChannelResponse<StreamChatGenerics>;
  members: ChannelMemberResponse<StreamChatGenerics>[];
  messages: MessageResponse<StreamChatGenerics>[];
  pinned_messages: MessageResponse<StreamChatGenerics>[];
  hidden?: boolean;
  membership?: ChannelMemberResponse<StreamChatGenerics> | null;
  pending_messages?: PendingMessageResponse<StreamChatGenerics>[];
  push_preferences?: PushPreference;
  read?: ReadResponse<StreamChatGenerics>[];
  threads?: ThreadResponse[];
  watcher_count?: number;
  watchers?: UserResponse<StreamChatGenerics>[];
};
```

From Go SDK
```go
type queryChannelResponseData struct {
	Channel         *Channel         `json:"channel"`
	Messages        []*Message       `json:"messages"`
	Read            []*ChannelRead   `json:"read"`
	Members         []*ChannelMember `json:"members"`
}
```

The Go SDK was missing these keys in the queryChannelResponse 
- pending_messages
- pinned_messages
- push_preferences
- ~threads~
- watcher_count
- watchers
- hidden

To keep the consistency between the SDKs and to avoid further customer requests like this in the future i have added these as well. 

> [!NOTE]
> I haven't added threads type yet, since any of the threads endpoints aren't implemented on GO SDK yet.  
