### PR TITLE
[CHA-831] feat: Implement RestoreUsers functionality and add corresponding tests

### DIFF
--- a/user.go
+++ b/user.go
@@ -657,3 +657,15 @@ func (c *Client) RevokeUsersTokens(ctx context.Context, userIDs []string, before
 	resp, err := c.PartialUpdateUsers(ctx, userUpdates)
 	return &resp.Response, err
 }
+
+func (c *Client) RestoreUsers(ctx context.Context, userIDs []string) (*Response, error) {
+	if len(userIDs) == 0 {
+		return nil, errors.New("userIDs are empty")
+	}
+
+	path := path.Join("users", "restore")
+
+	var resp Response
+	err := c.makeRequest(ctx, http.MethodPost, path, nil, userIDs, &resp)
+	return &resp, err
+}

--- a/user.go
+++ b/user.go
@@ -658,6 +658,10 @@ func (c *Client) RevokeUsersTokens(ctx context.Context, userIDs []string, before
 	return &resp.Response, err
 }
 
+type RestoreUserRequest struct {
+	UserIDs []string `json:"user_ids"`
+}
+
 func (c *Client) RestoreUsers(ctx context.Context, userIDs []string) (*Response, error) {
 	if len(userIDs) == 0 {
 		return nil, errors.New("userIDs are empty")
@@ -665,7 +669,9 @@ func (c *Client) RestoreUsers(ctx context.Context, userIDs []string) (*Response,
 
 	path := path.Join("users", "restore")
 
+	req := RestoreUserRequest{UserIDs: userIDs}
+
 	var resp Response
-	err := c.makeRequest(ctx, http.MethodPost, path, nil, userIDs, &resp)
+	err := c.makeRequest(ctx, http.MethodPost, path, nil, req, &resp)
 	return &resp, err
 }

--- a/user_test.go
+++ b/user_test.go
@@ -387,6 +387,72 @@ func TestClient_PartialUpdateUserWithTeam(t *testing.T) {
 	assert.Equal(t, map[string]string{"blue": "admin"}, partialResp.Users[user.ID].TeamsRole)
 }
 
+func TestClient_RestoreUsers(t *testing.T) {
+	c := initClient(t)
+	ctx := context.Background()
+
+	userIDs := randomUsersID(t, c, 3)
+	users := make([]*User, len(userIDs))
+	for i, userID := range userIDs {
+		users[i] = &User{ID: userID}
+	}
+
+	// create users
+	_, err := c.UpsertUsers(ctx, users...)
+	require.NoError(t, err, "UpsertUsers should not return an error")
+
+	// Test error case: empty userIDs
+	t.Run("Empty userIDs", func(t *testing.T) {
+		_, err := c.RestoreUsers(ctx, []string{})
+		require.Error(t, err, "RestoreUsers should return an error when userIDs is empty")
+		require.Equal(t, "userIDs are empty", err.Error(), "Error message should match")
+	})
+
+	// Test successful case
+	t.Run("Restore deactivated users", func(t *testing.T) {
+		// Deactivate the users first
+		_, err = c.DeactivateUsers(ctx, userIDs)
+		require.NoError(t, err, "DeactivateUsers should not return an error")
+
+		// Get the users to verify they are deactivated
+		resp, err := c.QueryUsers(ctx, &QueryUsersOptions{
+			QueryOption: QueryOption{
+				Filter: map[string]interface{}{
+					"id": map[string]interface{}{
+						"$in": userIDs,
+					},
+				},
+			},
+		})
+
+		require.NoError(t, err, "QueryUsers should not return an error")
+		// check that the users are deactivated
+		require.Equal(t, len(userIDs), len(resp.Users), "Should find all deactivated users")
+		for _, user := range resp.Users {
+			require.Contains(t, userIDs, user.ID, "User should be in the list of deactivated users")
+		}
+
+		// Restore the users
+		restoreResp, err := c.RestoreUsers(ctx, userIDs)
+		require.NoError(t, err, "RestoreUsers should not return an error")
+		require.NotNil(t, restoreResp, "Response should not be nil")
+
+		// Verify users are restored by querying them without IncludeDeactivatedUsers
+		verifyResp, err := c.QueryUsers(ctx, &QueryUsersOptions{
+			QueryOption: QueryOption{
+				Filter: map[string]interface{}{
+					"id": map[string]interface{}{
+						"$in": userIDs,
+					},
+				},
+			},
+		})
+		require.NoError(t, err, "QueryUsers should not return an error")
+		for _, user := range verifyResp.Users {
+			require.Contains(t, userIDs, user.ID, "User should be in the list of restored users")
+		}
+	})
+}
 func ExampleClient_UpsertUser() {
 	client, _ := NewClient("XXXX", "XXXX")
 	ctx := context.Background()


### PR DESCRIPTION
# Submit a pull request
https://linear.app/stream/issue/CHA-831/add-restoreusers-method-in-go-sdk


## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
- Added a new RestoreUsers method to the Client struct
- Performs validation to ensure the userIDs array is not empty
- Added unit tests that verify both error and success cases