### PR TITLE
[CHA-794] Add Query Threads

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,0 +1,21 @@
+package stream_chat
+
+type PagerRequest struct {
+	Limit *int    `json:"limit" validate:"omitempty,gte=0,lte=100"`
+	Next  *string `json:"next"`
+	Prev  *string `json:"prev"`
+}
+type SortParamRequestList []*SortParamRequest
+
+type SortParamRequest struct {
+	// Name of field to sort by
+	Field string `json:"field"`
+
+	// Direction is the sorting direction, 1 for Ascending, -1 for Descending, default is 1
+	Direction int `json:"direction"`
+}
+
+type PagerResponse struct {
+	Next *string `json:"next,omitempty"`
+	Prev *string `json:"prev,omitempty"`
+}

--- a/thread.go
+++ b/thread.go
@@ -1,0 +1,102 @@
+package stream_chat
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type QueryThreadsRequest struct {
+	User   *User  `json:"user,omitempty"`
+	UserID string `json:"user_id,omitempty"`
+
+	Filter map[string]any        `json:"filter,omitempty"`
+	Sort   *SortParamRequestList `json:"sort,omitempty"`
+	Watch  *bool                 `json:"watch,omitempty"`
+	PagerRequest
+}
+
+type QueryThreadsResponse struct {
+	Threads []ThreadResponse `json:"threads"`
+	Response
+	PagerResponse
+}
+
+type ThreadResponse struct {
+	ChannelCID             string             `json:"channel_cid"`
+	Channel                *Channel           `json:"channel,omitempty"`
+	ParentMessageID        string             `json:"parent_message_id"`
+	ParentMessage          *MessageResponse   `json:"parent_message,omitempty"`
+	CreatedByUserID        string             `json:"created_by_user_id"`
+	CreatedBy              *UsersResponse     `json:"created_by,omitempty"`
+	ReplyCount             int                `json:"reply_count,omitempty"`
+	ParticipantCount       int                `json:"participant_count,omitempty"`
+	ActiveParticipantCount int                `json:"active_participant_count,omitempty"`
+	Participants           ThreadParticipants `json:"thread_participants,omitempty"`
+	LastMessageAt          *time.Time         `json:"last_message_at,omitempty"`
+	CreatedAt              *time.Time         `json:"created_at"`
+	UpdatedAt              *time.Time         `json:"updated_at"`
+	DeletedAt              *time.Time         `json:"deleted_at,omitempty"`
+	Title                  string             `json:"title"`
+	Custom                 map[string]any     `json:"custom"`
+
+	LatestReplies []MessageResponse `json:"latest_replies,omitempty"`
+	Read          ChannelRead       `json:"read,omitempty"`
+	Draft         Draft
+}
+
+type Thread struct {
+	AppPK int `json:"app_pk"`
+
+	ChannelCID string   `json:"channel_cid"`
+	Channel    *Channel `json:"channel,omitempty"`
+
+	ParentMessageID string   `json:"parent_message_id"`
+	ParentMessage   *Message `json:"parent_message,omitempty"`
+
+	CreatedByUserID string `json:"created_by_user_id"`
+	CreatedBy       *User  `json:"created_by,omitempty"`
+
+	ReplyCount             int                `json:"reply_count,omitempty"`
+	ParticipantCount       int                `json:"participant_count,omitempty"`
+	ActiveParticipantCount int                `json:"active_participant_count,omitempty"`
+	Participants           ThreadParticipants `json:"thread_participants,omitempty"`
+
+	LastMessageAt time.Time  `json:"last_message_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+	DeletedAt     *time.Time `json:"deleted_at,omitempty"`
+
+	Title  string         `json:"title"`
+	Custom map[string]any `json:"custom"`
+}
+
+type ThreadParticipant struct {
+	AppPK int `json:"app_pk"`
+
+	ChannelCID string `json:"channel_cid"`
+
+	LastThreadMessageAt *time.Time `json:"last_thread_message_at"`
+	ThreadID            string     `json:"thread_id,omitempty"`
+
+	UserID string `json:"user_id,omitempty"`
+	User   *User  `json:"user,omitempty"`
+
+	CreatedAt    time.Time  `json:"created_at"`
+	LeftThreadAt *time.Time `json:"left_thread_at,omitempty"`
+	LastReadAt   time.Time  `json:"last_read_at"`
+
+	Custom map[string]interface{} `json:"custom"`
+}
+
+type ThreadParticipants []*ThreadParticipant
+
+func (c *Client) QueryThreads(ctx context.Context, query *QueryThreadsRequest) (*QueryThreadsResponse, error) {
+	var resp QueryThreadsResponse
+	err := c.makeRequest(ctx, http.MethodPost, "threads", nil, query, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}

--- a/thread_test.go
+++ b/thread_test.go
@@ -1,0 +1,157 @@
+package stream_chat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_QueryThreads(t *testing.T) {
+	c := initClient(t)
+	ctx := context.Background()
+
+	t.Run("basic query", func(t *testing.T) {
+		membersID, ch, parentMsg, replyMsg := testThreadSetup(t, c, 3)
+
+		query := &QueryThreadsRequest{
+			Filter: map[string]any{
+				"channel_cid": ch.CID,
+			},
+			Sort: &SortParamRequestList{
+				{
+					Field:     "created_at",
+					Direction: -1,
+				},
+			},
+			PagerRequest: PagerRequest{
+				Limit: intPtr(10),
+			},
+			UserID: membersID[0],
+		}
+
+		resp, err := c.QueryThreads(ctx, query)
+		require.NoError(t, err)
+		require.NotNil(t, resp, "response should not be nil")
+		require.NotEmpty(t, resp.Threads, "threads should not be empty")
+
+		thread := resp.Threads[0]
+		assertThreadData(t, thread, ch, parentMsg, replyMsg)
+		assertThreadParticipants(t, thread, ch.CreatedBy.ID)
+
+		assert.Empty(t, resp.PagerResponse)
+	})
+
+	t.Run("with pagination", func(t *testing.T) {
+		membersID, ch, parentMsg1, replyMsg1 := testThreadSetup(t, c, 3)
+
+		// Create a second thread
+		parentMsg2, err := ch.SendMessage(ctx, &Message{Text: "Parent message for thread 2"}, ch.CreatedBy.ID)
+		require.NoError(t, err, "send second parent message")
+
+		replyMsg2, err := ch.SendMessage(ctx, &Message{
+			Text:     "Reply message 2",
+			ParentID: parentMsg2.Message.ID,
+		}, ch.CreatedBy.ID)
+		require.NoError(t, err, "send second reply message")
+
+		// First page query
+		query := &QueryThreadsRequest{
+			Filter: map[string]any{
+				"channel_cid": ch.CID,
+			},
+			Sort: &SortParamRequestList{
+				{
+					Field:     "created_at",
+					Direction: 1,
+				},
+			},
+			PagerRequest: PagerRequest{
+				Limit: intPtr(1),
+			},
+			UserID: membersID[0],
+		}
+
+		resp, err := c.QueryThreads(ctx, query)
+		require.NoError(t, err)
+		require.NotNil(t, resp, "response should not be nil")
+		require.NotEmpty(t, resp.Threads, "threads should not be empty")
+
+		thread := resp.Threads[0]
+		assertThreadData(t, thread, ch, parentMsg1, replyMsg1)
+		assertThreadParticipants(t, thread, ch.CreatedBy.ID)
+
+		// Second page query
+		query2 := &QueryThreadsRequest{
+			Filter: map[string]any{
+				"channel_cid": ch.CID,
+			},
+			Sort: &SortParamRequestList{
+				{
+					Field:     "created_at",
+					Direction: -1,
+				},
+			},
+			PagerRequest: PagerRequest{
+				Limit: intPtr(1),
+				Next:  resp.Next,
+			},
+			UserID: membersID[0],
+		}
+
+		resp, err = c.QueryThreads(ctx, query2)
+		require.NoError(t, err)
+		require.NotNil(t, resp, "response should not be nil")
+		require.NotEmpty(t, resp.Threads, "threads should not be empty")
+
+		thread = resp.Threads[0]
+		assertThreadData(t, thread, ch, parentMsg2, replyMsg2)
+		assertThreadParticipants(t, thread, ch.CreatedBy.ID)
+	})
+}
+
+// testThreadSetup creates a channel with members and returns necessary test data
+func testThreadSetup(t *testing.T, c *Client, numMembers int) ([]string, *Channel, *MessageResponse, *MessageResponse) {
+	membersID := randomUsersID(t, c, numMembers)
+	ch := initChannel(t, c, membersID...)
+
+	// Create a parent message
+	parentMsg, err := ch.SendMessage(context.Background(), &Message{Text: "Parent message for thread"}, ch.CreatedBy.ID)
+	require.NoError(t, err, "send parent message")
+
+	// Create a thread by sending a reply
+	replyMsg, err := ch.SendMessage(context.Background(), &Message{
+		Text:     "Reply message",
+		ParentID: parentMsg.Message.ID,
+	}, ch.CreatedBy.ID)
+	require.NoError(t, err, "send reply message")
+
+	return membersID, ch, parentMsg, replyMsg
+}
+
+// assertThreadData validates common thread data fields
+func assertThreadData(t *testing.T, thread ThreadResponse, ch *Channel, parentMsg, replyMsg *MessageResponse) {
+	assert.Equal(t, ch.CID, thread.ChannelCID, "channel CID should match")
+	assert.Equal(t, parentMsg.Message.ID, thread.ParentMessageID, "parent message ID should match")
+	assert.Equal(t, ch.CreatedBy.ID, thread.CreatedByUserID, "created by user ID should match")
+	assert.Equal(t, 1, thread.ReplyCount, "reply count should be 1")
+	assert.Equal(t, 1, thread.ParticipantCount, "participant count should be 1")
+	assert.Equal(t, parentMsg.Message.Text, thread.Title, "title should not be empty")
+	assert.Equal(t, replyMsg.Message.CreatedAt, thread.CreatedAt, "created at should not be zero")
+	assert.Equal(t, replyMsg.Message.UpdatedAt, thread.UpdatedAt, "updated at should not be zero")
+	assert.Nil(t, thread.DeletedAt, "deleted at should be nil")
+}
+
+// assertThreadParticipants validates thread participant data
+func assertThreadParticipants(t *testing.T, thread ThreadResponse, createdByID string) {
+	require.Len(t, thread.Participants, 1, "should have one participant")
+	assert.Equal(t, createdByID, thread.Participants[0].UserID, "participant user ID should match")
+	assert.NotZero(t, thread.Participants[0].CreatedAt, "participant created at should not be zero")
+	assert.NotZero(t, thread.Participants[0].LastReadAt, "participant last read at should not be zero")
+}
+
+// Helper function to create a pointer to an int
+func intPtr(i int) *int {
+	return &i
+}

--- a/thread_test.go
+++ b/thread_test.go
@@ -15,6 +15,7 @@ func TestClient_QueryThreads(t *testing.T) {
 	t.Run("basic query", func(t *testing.T) {
 		membersID, ch, parentMsg, replyMsg := testThreadSetup(t, c, 3)
 
+		limit := 10
 		query := &QueryThreadsRequest{
 			Filter: map[string]any{
 				"channel_cid": map[string]any{
@@ -28,7 +29,7 @@ func TestClient_QueryThreads(t *testing.T) {
 				},
 			},
 			PagerRequest: PagerRequest{
-				Limit: intPtr(10),
+				Limit: &limit,
 			},
 			UserID: membersID[0],
 		}
@@ -47,6 +48,7 @@ func TestClient_QueryThreads(t *testing.T) {
 
 	t.Run("with pagination", func(t *testing.T) {
 		membersID, ch, parentMsg1, replyMsg1 := testThreadSetup(t, c, 3)
+		limit := 1
 
 		// Create a second thread
 		parentMsg2, err := ch.SendMessage(ctx, &Message{Text: "Parent message for thread 2"}, ch.CreatedBy.ID)
@@ -72,7 +74,7 @@ func TestClient_QueryThreads(t *testing.T) {
 				},
 			},
 			PagerRequest: PagerRequest{
-				Limit: intPtr(1),
+				Limit: &limit,
 			},
 			UserID: membersID[0],
 		}
@@ -100,7 +102,7 @@ func TestClient_QueryThreads(t *testing.T) {
 				},
 			},
 			PagerRequest: PagerRequest{
-				Limit: intPtr(1),
+				Limit: &limit,
 				Next:  resp.Next,
 			},
 			UserID: membersID[0],
@@ -155,9 +157,4 @@ func assertThreadParticipants(t *testing.T, thread ThreadResponse, createdByID s
 	assert.Equal(t, createdByID, thread.Participants[0].UserID, "participant user ID should match")
 	assert.NotZero(t, thread.Participants[0].CreatedAt, "participant created at should not be zero")
 	assert.NotZero(t, thread.Participants[0].LastReadAt, "participant last read at should not be zero")
-}
-
-// Helper function to create a pointer to an int
-func intPtr(i int) *int {
-	return &i
 }

--- a/thread_test.go
+++ b/thread_test.go
@@ -17,7 +17,9 @@ func TestClient_QueryThreads(t *testing.T) {
 
 		query := &QueryThreadsRequest{
 			Filter: map[string]any{
-				"channel_cid": ch.CID,
+				"channel_cid": map[string]any{
+					"$eq": ch.CID,
+				},
 			},
 			Sort: &SortParamRequestList{
 				{
@@ -59,7 +61,9 @@ func TestClient_QueryThreads(t *testing.T) {
 		// First page query
 		query := &QueryThreadsRequest{
 			Filter: map[string]any{
-				"channel_cid": ch.CID,
+				"channel_cid": map[string]any{
+					"$eq": ch.CID,
+				},
 			},
 			Sort: &SortParamRequestList{
 				{
@@ -85,7 +89,9 @@ func TestClient_QueryThreads(t *testing.T) {
 		// Second page query
 		query2 := &QueryThreadsRequest{
 			Filter: map[string]any{
-				"channel_cid": ch.CID,
+				"channel_cid": map[string]any{
+					"$eq": ch.CID,
+				},
 			},
 			Sort: &SortParamRequestList{
 				{


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

We added support of filter and sort parameter in QueryThreads endpoint. This MR adds the query_thread functionality to be used for client.

```go
limit := 10
query := &QueryThreadsRequest{
	Filter: map[string]any{
		"channel_cid": map[string]any{
			"$eq": ch.CID,
		},
	},
	Sort: &SortParamRequestList{
		{
			Field:     "created_at",
			Direction: -1,
		},
	},
	PagerRequest: PagerRequest{
		Limit: &limit,
	},
	UserID: membersID[0],
}

resp, err := c.QueryThreads(ctx, query)
```