### PR TITLE
feat(message): add MessageImmediate option for setting pending=false

### DIFF
--- a/message.go
+++ b/message.go
@@ -123,7 +123,7 @@ type messageRequest struct {
 	Message                messageRequestMessage `json:"message"`
 	SkipPush               bool                  `json:"skip_push,omitempty"`
 	SkipEnrichURL          bool                  `json:"skip_enrich_url,omitempty"`
-	Pending                bool                  `json:"pending,omitempty"`
+	Pending                *bool                 `json:"pending,omitempty"`
 	IsPendingMessage       bool                  `json:"is_pending_message,omitempty"`
 	PendingMessageMetadata map[string]string     `json:"pending_message_metadata,omitempty"`
 	KeepChannelHidden      bool                  `json:"keep_channel_hidden,omitempty"`
@@ -227,8 +227,20 @@ func MessageSkipEnrichURL(r *messageRequest) {
 
 // MessagePending is a flag that makes this a pending message.
 func MessagePending(r *messageRequest) {
-	if r != nil {
-		r.Pending = true
+	withPending(true)(r)
+}
+
+// MessageImmediate sets message.Pending=false explicitly.
+func MessageImmediate(r *messageRequest) {
+	withPending(false)(r)
+}
+
+// withPending returns an option that sets the Pending flag to the specified value.
+func withPending(pending bool) SendMessageOption {
+	return func(r *messageRequest) {
+		if r != nil {
+			r.Pending = &pending
+		}
 	}
 }
 

--- a/message.go
+++ b/message.go
@@ -225,18 +225,14 @@ func MessageSkipEnrichURL(r *messageRequest) {
 	}
 }
 
-// MessagePending is a flag that makes this a pending message.
+// MessagePending sets a flag that marks this message as pending.
+// Deprecated: Use WithPending(true) instead.
 func MessagePending(r *messageRequest) {
-	withPending(true)(r)
+	WithPending(true)(r)
 }
 
-// MessageImmediate sets message.Pending=false explicitly.
-func MessageImmediate(r *messageRequest) {
-	withPending(false)(r)
-}
-
-// withPending returns an option that sets the Pending flag to the specified value.
-func withPending(pending bool) SendMessageOption {
+// WithPending returns an option that sets the Pending flag to the specified value.
+func WithPending(pending bool) SendMessageOption {
 	return func(r *messageRequest) {
 		if r != nil {
 			r.Pending = &pending

--- a/message_test.go
+++ b/message_test.go
@@ -69,7 +69,7 @@ func TestClient_SendMessage_Pending(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestClient_SendMessage_Immediate(t *testing.T) {
+func TestClient_SendMessage_WithPendingFalse(t *testing.T) {
 	c := initClient(t)
 	user := randomUser(t, c)
 
@@ -79,8 +79,8 @@ func TestClient_SendMessage_Immediate(t *testing.T) {
 	resp1, err := c.CreateChannel(ctx, ch.Type, ch.ID, user.ID, nil)
 	require.NoError(t, err)
 
-	msg := &Message{Text: "test immediate message"}
-	messageResp, err := resp1.Channel.SendMessage(ctx, msg, user.ID, MessageImmediate)
+	msg := &Message{Text: "message with WithPending(false) - non-pending message"}
+	messageResp, err := resp1.Channel.SendMessage(ctx, msg, user.ID, WithPending(false))
 	require.NoError(t, err)
 
 	// Get the message to verify it's not in pending state


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

**Add MessageImmediate option for explicit pending=false messaging**
This PR introduces a new MessageImmediate function that explicitly sets the message's pending flag to false. This provides a clearer and more flexible API for users who need to control the pending status of their messages.

Changes:
- Added MessageImmediate function as a counterpart to the existing MessagePending
- Made both functions use the same underlying implementation
- Added unit test to verify the new functionality works as expected

**Why not just remove omitempty?**

Removing the omitempty tag from the Pending field would be a poor solution because:
• It would unnecessarily increase payload size for all requests
• It changes the API contract for all clients
• It would send the "pending" field in all requests even when it's not needed
• It doesn't follow Go idioms for optional parameters
• It could cause backward compatibility issues with the Stream API
The new function approach maintains API compatibility while providing explicit control over the pending flag when needed.