### PR TITLE
feat: add optional force_moderation field parameter to the send message request

### DIFF
--- a/message.go
+++ b/message.go
@@ -127,6 +127,7 @@ type messageRequest struct {
 	IsPendingMessage       bool                  `json:"is_pending_message,omitempty"`
 	PendingMessageMetadata map[string]string     `json:"pending_message_metadata,omitempty"`
 	KeepChannelHidden      bool                  `json:"keep_channel_hidden,omitempty"`
+	ForceModeration        *bool                 `json:"force_moderation,omitempty"`
 }
 
 type messageRequestMessage struct {
@@ -236,6 +237,15 @@ func WithPending(pending bool) SendMessageOption {
 	return func(r *messageRequest) {
 		if r != nil {
 			r.Pending = &pending
+		}
+	}
+}
+
+// WithForceModeration returns an option that sets the ForceModeration flag to the specified value.
+func WithForceModeration(forceModeration bool) SendMessageOption {
+	return func(r *messageRequest) {
+		if r != nil {
+			r.ForceModeration = &forceModeration
 		}
 	}
 }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
- Adds an optional `force_moderation` field of boolean type to the send message request

Example usage: 
`message, err := channel.SendMessage(ctx, message, userID, WithForceModeration(true))`
