### PR TITLE
Add EventHooks field to AppSetting

### DIFF
--- a/app.go
+++ b/app.go
@@ -192,33 +192,48 @@ type Policy struct {
 }
 
 type HookType string
+type CallbackMode string
 
 const (
-	WebhookHook HookType = "webhook"
-	SQSHook     HookType = "sqs"
-	SNSHook     HookType = "sns"
+	WebhookHook    HookType = "webhook"
+	SQSHook        HookType = "sqs"
+	SNSHook        HookType = "sns"
+	PendingMessage HookType = "pending_message"
+
+	CallbackModeNone  CallbackMode = "CALLBACK_MODE_NONE"
+	CallbackModeREST  CallbackMode = "CALLBACK_MODE_REST"
+	CallbackModeTwirp CallbackMode = "CALLBACK_MODE_TWIRP"
 )
 
+type Callback struct {
+	Mode CallbackMode `json:"mode"`
+}
+
 type EventHook struct {
-	ID          string    `json:"id"`
-	HookType    HookType  `json:"hook_type"`
-	Enabled     bool      `json:"enabled"`
-	EventTypes  []string  `json:"event_types"`
-	WebhookURL  string    `json:"webhook_url,omitempty"`
-	SQSQueueURL string    `json:"sqs_queue_url,omitempty"`
-	SQSRegion   string    `json:"sqs_region,omitempty"`
-	SQSAuthType string    `json:"sqs_auth_type,omitempty"`
-	SQSKey      string    `json:"sqs_key,omitempty"`
-	SQSSecret   string    `json:"sqs_secret,omitempty"`
-	SQSRoleARN  string    `json:"sqs_role_arn,omitempty"`
-	SNSTopicARN string    `json:"sns_topic_arn,omitempty"`
-	SNSRegion   string    `json:"sns_region,omitempty"`
-	SNSAuthType string    `json:"sns_auth_type,omitempty"`
-	SNSKey      string    `json:"sns_key,omitempty"`
-	SNSSecret   string    `json:"sns_secret,omitempty"`
-	SNSRoleARN  string    `json:"sns_role_arn,omitempty"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID          string   `json:"id"`
+	HookType    HookType `json:"hook_type"`
+	Enabled     bool     `json:"enabled"`
+	EventTypes  []string `json:"event_types"`
+	WebhookURL  string   `json:"webhook_url,omitempty"`
+	SQSQueueURL string   `json:"sqs_queue_url,omitempty"`
+	SQSRegion   string   `json:"sqs_region,omitempty"`
+	SQSAuthType string   `json:"sqs_auth_type,omitempty"`
+	SQSKey      string   `json:"sqs_key,omitempty"`
+	SQSSecret   string   `json:"sqs_secret,omitempty"`
+	SQSRoleARN  string   `json:"sqs_role_arn,omitempty"`
+	SNSTopicARN string   `json:"sns_topic_arn,omitempty"`
+	SNSRegion   string   `json:"sns_region,omitempty"`
+	SNSAuthType string   `json:"sns_auth_type,omitempty"`
+	SNSKey      string   `json:"sns_key,omitempty"`
+	SNSSecret   string   `json:"sns_secret,omitempty"`
+	SNSRoleARN  string   `json:"sns_role_arn,omitempty"`
+
+	// pending message config
+	TimeoutMs int       `json:"timeout_ms,omitempty"`
+	Callback  *Callback `json:"callback,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type AppResponse struct {

--- a/app.go
+++ b/app.go
@@ -52,6 +52,7 @@ type AppSettings struct {
 	EnforceUniqueUsernames    *string                       `json:"enforce_unique_usernames,omitempty"`
 	ChannelHideMembersOnly    *bool                         `json:"channel_hide_members_only,omitempty"`
 	AsyncModerationConfig     *AsyncModerationConfiguration `json:"async_moderation_config,omitempty"`
+	EventHooks                []EventHook                   `json:"event_hooks,omitempty"`
 }
 
 func (a *AppSettings) SetDisableAuth(b bool) *AppSettings {
@@ -91,6 +92,11 @@ func (a *AppSettings) SetGrants(g map[string][]string) *AppSettings {
 
 func (a *AppSettings) SetAsyncModerationConfig(c AsyncModerationConfiguration) *AppSettings {
 	a.AsyncModerationConfig = &c
+	return a
+}
+
+func (a *AppSettings) SetEventHooks(eventHooks []EventHook) *AppSettings {
+	a.EventHooks = eventHooks
 	return a
 }
 
@@ -183,6 +189,36 @@ type Policy struct {
 	Priority  int       `json:"priority"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type HookType string
+
+const (
+	WebhookHook HookType = "webhook"
+	SQSHook     HookType = "sqs"
+	SNSHook     HookType = "sns"
+)
+
+type EventHook struct {
+	ID          string    `json:"id"`
+	HookType    HookType  `json:"hook_type"`
+	Enabled     bool      `json:"enabled"`
+	EventTypes  []string  `json:"event_types"`
+	WebhookURL  string    `json:"webhook_url,omitempty"`
+	SQSQueueURL string    `json:"sqs_queue_url,omitempty"`
+	SQSRegion   string    `json:"sqs_region,omitempty"`
+	SQSAuthType string    `json:"sqs_auth_type,omitempty"`
+	SQSKey      string    `json:"sqs_key,omitempty"`
+	SQSSecret   string    `json:"sqs_secret,omitempty"`
+	SQSRoleARN  string    `json:"sqs_role_arn,omitempty"`
+	SNSTopicARN string    `json:"sns_topic_arn,omitempty"`
+	SNSRegion   string    `json:"sns_region,omitempty"`
+	SNSAuthType string    `json:"sns_auth_type,omitempty"`
+	SNSKey      string    `json:"sns_key,omitempty"`
+	SNSSecret   string    `json:"sns_secret,omitempty"`
+	SNSRoleARN  string    `json:"sns_role_arn,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 type AppResponse struct {

--- a/app_test.go
+++ b/app_test.go
@@ -62,7 +62,7 @@ func TestClient_UpdateAppSettingsClearing(t *testing.T) {
 
 	_, err := c.UpdateAppSettings(ctx, settings)
 	if err != nil {
-		assert.Equal(t, err.Error(), "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks.")
+		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks."`)
 		return
 	}
 	require.NoError(t, err)
@@ -71,14 +71,14 @@ func TestClient_UpdateAppSettingsClearing(t *testing.T) {
 	settings.SqsURL = &sqsURL
 	_, err = c.UpdateAppSettings(ctx, settings)
 	if err != nil {
-		assert.Equal(t, err.Error(), "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks.")
+		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks."`)
 		return
 	}
 	require.NoError(t, err)
 
 	s, err := c.GetAppSettings(ctx)
 	if err != nil {
-		assert.Equal(t, err.Error(), "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks.")
+		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks."`)
 		return
 	}
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestClientUpdateEventHooks(t *testing.T) {
 	settings := NewAppSettings().SetEventHooks(eventHooks)
 	_, err := c.UpdateAppSettings(ctx, settings)
 	if err != nil {
-		assert.Equal(t, err.Error(), "cannot set event hooks in hook v1 system")
+		assert.Equal(t, err.Error(), `UpdateApp failed with error: "cannot set event hooks in hook v1 system"`)
 		return
 	}
 	require.NoError(t, err)

--- a/app_test.go
+++ b/app_test.go
@@ -62,7 +62,7 @@ func TestClient_UpdateAppSettingsClearing(t *testing.T) {
 
 	_, err := c.UpdateAppSettings(ctx, settings)
 	if err != nil {
-		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks."`)
+		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, SNS secret, or async moderation config in new hook v2 system. Use the event_hooks field to configure webhooks."`)
 		return
 	}
 	require.NoError(t, err)
@@ -71,14 +71,14 @@ func TestClient_UpdateAppSettingsClearing(t *testing.T) {
 	settings.SqsURL = &sqsURL
 	_, err = c.UpdateAppSettings(ctx, settings)
 	if err != nil {
-		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks."`)
+		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, SNS secret, or async moderation config in new hook v2 system. Use the event_hooks field to configure webhooks."`)
 		return
 	}
 	require.NoError(t, err)
 
 	s, err := c.GetAppSettings(ctx)
 	if err != nil {
-		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks."`)
+		assert.Equal(t, err.Error(), `UpdateApp failed with error: "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, SNS secret, or async moderation config in new hook v2 system. Use the event_hooks field to configure webhooks."`)
 		return
 	}
 	require.NoError(t, err)

--- a/app_test.go
+++ b/app_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,14 +61,26 @@ func TestClient_UpdateAppSettingsClearing(t *testing.T) {
 	settings.SqsSecret = &sqsSecret
 
 	_, err := c.UpdateAppSettings(ctx, settings)
+	if err != nil {
+		assert.Equal(t, err.Error(), "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks.")
+		return
+	}
 	require.NoError(t, err)
 
 	sqsURL = ""
 	settings.SqsURL = &sqsURL
 	_, err = c.UpdateAppSettings(ctx, settings)
+	if err != nil {
+		assert.Equal(t, err.Error(), "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks.")
+		return
+	}
 	require.NoError(t, err)
 
 	s, err := c.GetAppSettings(ctx)
+	if err != nil {
+		assert.Equal(t, err.Error(), "Cannot set webhook URL, webhook events, SQS URL, SQS key, SQS secret, SNS topic ARN, SNS key, or SNS secret in new hook v2 system. Use the event_hooks field to configure webhooks.")
+		return
+	}
 	require.NoError(t, err)
 	require.Equal(t, *settings.SqsURL, *s.App.SqsURL)
 }
@@ -111,6 +124,28 @@ func TestClient_CheckPush(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, msgResp.Message.ID, resp.RenderedMessage["message_id"])
+}
+
+func TestClientUpdateEventHooks(t *testing.T) {
+	c := initClient(t)
+	ctx := context.Background()
+
+	eventHooks := []EventHook{
+		{
+			HookType:   WebhookHook,
+			Enabled:    true,
+			EventTypes: []string{"message.new"},
+			WebhookURL: "http://test-webhook-url",
+		},
+	}
+
+	settings := NewAppSettings().SetEventHooks(eventHooks)
+	_, err := c.UpdateAppSettings(ctx, settings)
+	if err != nil {
+		assert.Equal(t, err.Error(), "cannot set event hooks in hook v1 system")
+		return
+	}
+	require.NoError(t, err)
 }
 
 // See https://getstream.io/chat/docs/app_settings_auth/ for


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

- Adding new field `EventHooks` to `AppSetting`
- Handle the error returned when `EventHooks` is set when the system hasn't migrated to hook v2
- Handle the error returned when old fields are set when the system has migrated to hook v2
