### PR TITLE
[CHA-941]: supporting passing member

### DIFF
--- a/ban_test.go
+++ b/ban_test.go
@@ -14,7 +14,7 @@ func TestShadowBanUser(t *testing.T) {
 	userC := randomUser(t, c)
 	ctx := context.Background()
 
-	ch := initChannel(t, c, userA.ID, userB.ID, userC.ID)
+	ch := initChannel(t, c, userA, userB, userC)
 	resp, err := c.CreateChannel(ctx, ch.Type, ch.ID, userA.ID, nil)
 	require.NoError(t, err)
 
@@ -113,7 +113,7 @@ func TestChannelBanUnban(t *testing.T) {
 	c := initClient(t)
 	target := randomUser(t, c)
 	user := randomUser(t, c)
-	ch := initChannel(t, c, user.ID, target.ID)
+	ch := initChannel(t, c, user, target)
 	ctx := context.Background()
 
 	_, err := ch.BanUser(ctx, target.ID, user.ID, BanWithReason("spammer"), BanWithExpiration(60))

--- a/channel.go
+++ b/channel.go
@@ -155,7 +155,7 @@ type ChannelRequest struct {
 	AutoTranslationLanguage string                 `json:"auto_translation_language,omitempty"`
 	Frozen                  *bool                  `json:"frozen,omitempty"`
 	Disabled                *bool                  `json:"disabled,omitempty"`
-	Members                 []string               `json:"members,omitempty"`
+	Members                 []ChannelMember        `json:"members,omitempty"`
 	Invites                 []string               `json:"invites,omitempty"`
 	ExtraData               map[string]interface{} `json:"-"`
 }
@@ -810,7 +810,7 @@ func (c *Client) CreateChannel(ctx context.Context, chanType, chanID, userID str
 }
 
 // CreateChannelWithMembers creates new channel of given type and id or returns already created one.
-func (c *Client) CreateChannelWithMembers(ctx context.Context, chanType, chanID, userID string, memberIDs ...string) (*CreateChannelResponse, error) {
+func (c *Client) CreateChannelWithMembers(ctx context.Context, chanType, chanID, userID string, memberIDs ...ChannelMember) (*CreateChannelResponse, error) {
 	return c.CreateChannel(ctx, chanType, chanID, userID, &ChannelRequest{Members: memberIDs})
 }
 

--- a/channel.go
+++ b/channel.go
@@ -374,7 +374,7 @@ func (ch *Channel) GetMessages(ctx context.Context, messageIDs []string) (*GetMe
 }
 
 type addMembersOptions struct {
-	MemberIDs []string `json:"add_members"`
+	MemberIDs []ChannelMember `json:"add_members"`
 
 	RolesAssignement []*RoleAssignment `json:"assign_roles"`
 	HideHistory      bool              `json:"hide_history"`
@@ -402,13 +402,13 @@ func AddMembersWithRolesAssignment(assignements []*RoleAssignment) func(*addMemb
 }
 
 // AddMembers adds members with given user IDs to the channel.
-func (ch *Channel) AddMembers(ctx context.Context, userIDs []string, options ...AddMembersOptions) (*Response, error) {
-	if len(userIDs) == 0 {
+func (ch *Channel) AddMembers(ctx context.Context, members []ChannelMember, options ...AddMembersOptions) (*Response, error) {
+	if len(members) == 0 {
 		return nil, errors.New("user IDs are empty")
 	}
 
 	opts := &addMembersOptions{
-		MemberIDs: userIDs,
+		MemberIDs: members,
 	}
 
 	for _, fn := range options {

--- a/channel.go
+++ b/channel.go
@@ -374,7 +374,7 @@ func (ch *Channel) GetMessages(ctx context.Context, messageIDs []string) (*GetMe
 }
 
 type addMembersOptions struct {
-	MemberIDs []ChannelMember `json:"add_members"`
+	Members []ChannelMember `json:"add_members"`
 
 	RolesAssignement []*RoleAssignment `json:"assign_roles"`
 	HideHistory      bool              `json:"hide_history"`
@@ -408,7 +408,7 @@ func (ch *Channel) AddMembers(ctx context.Context, members []ChannelMember, opti
 	}
 
 	opts := &addMembersOptions{
-		MemberIDs: members,
+		Members: members,
 	}
 
 	for _, fn := range options {
@@ -810,8 +810,8 @@ func (c *Client) CreateChannel(ctx context.Context, chanType, chanID, userID str
 }
 
 // CreateChannelWithMembers creates new channel of given type and id or returns already created one.
-func (c *Client) CreateChannelWithMembers(ctx context.Context, chanType, chanID, userID string, memberIDs ...ChannelMember) (*CreateChannelResponse, error) {
-	return c.CreateChannel(ctx, chanType, chanID, userID, &ChannelRequest{Members: memberIDs})
+func (c *Client) CreateChannelWithMembers(ctx context.Context, chanType, chanID, userID string, members ...ChannelMember) (*CreateChannelResponse, error) {
+	return c.CreateChannel(ctx, chanType, chanID, userID, &ChannelRequest{Members: members})
 }
 
 type SendFileRequest struct {

--- a/channel_test.go
+++ b/channel_test.go
@@ -77,12 +77,12 @@ func TestClient_CreateChannel(t *testing.T) {
 		{"create channel without ID and members", "messaging", "", userID, nil, nil, true},
 		{
 			"create channel without ID but with members", "messaging", "", userID,
-			&ChannelRequest{Members: randomUsersID(t, c, 2)},
+			&ChannelRequest{Members: randomUsersChannelMember(t, c, 2)},
 			nil, false,
 		},
 		{
 			"create channel with HideForCreator", "messaging", "", userID,
-			&ChannelRequest{Members: []string{userID, randomUsersID(t, c, 1)[0]}},
+			&ChannelRequest{Members: []ChannelMember{ChannelMember{UserID: userID}, randomUsersChannelMember(t, c, 1)[0]}},
 			[]CreateChannelOptionFunc{HideForCreator(true)},
 			false,
 		},
@@ -485,9 +485,9 @@ func TestChannel_PartialUpdate(t *testing.T) {
 	users := randomUsers(t, c, 5)
 	ctx := context.Background()
 
-	members := make([]string, 0, len(users))
+	members := make([]ChannelMember, 0, len(users))
 	for i := range users {
-		members = append(members, users[i].ID)
+		members = append(members, ChannelMember{UserID: users[i].ID})
 	}
 
 	req := &ChannelRequest{Members: members, ExtraData: map[string]interface{}{"color": "blue", "age": 30}}
@@ -516,9 +516,9 @@ func TestChannel_MemberPartialUpdate(t *testing.T) {
 	users := randomUsers(t, c, 5)
 	ctx := context.Background()
 
-	members := make([]string, 0, len(users))
+	members := make([]ChannelMember, 0, len(users))
 	for i := range users {
-		members = append(members, users[i].ID)
+		members = append(members, ChannelMember{UserID: users[i].ID})
 	}
 
 	req := &ChannelRequest{Members: members}
@@ -526,7 +526,7 @@ func TestChannel_MemberPartialUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	ch := resp.Channel
-	member, err := ch.PartialUpdateMember(ctx, members[0], PartialUpdate{
+	member, err := ch.PartialUpdateMember(ctx, members[0].UserID, PartialUpdate{
 		Set: map[string]interface{}{
 			"color": "red",
 		},
@@ -535,7 +535,7 @@ func TestChannel_MemberPartialUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "red", member.ChannelMember.ExtraData["color"])
 
-	member, err = ch.PartialUpdateMember(ctx, members[0], PartialUpdate{
+	member, err = ch.PartialUpdateMember(ctx, members[0].UserID, PartialUpdate{
 		Set: map[string]interface{}{
 			"age": "18",
 		},
@@ -622,16 +622,16 @@ func TestChannel_AcceptInvite(t *testing.T) {
 	ctx := context.Background()
 	users := randomUsers(t, c, 5)
 
-	members := make([]string, 0, len(users))
+	members := make([]ChannelMember, 0, len(users))
 	for i := range users {
-		members = append(members, users[i].ID)
+		members = append(members, ChannelMember{UserID: users[i].ID})
 	}
 
-	req := &ChannelRequest{Members: members, Invites: []string{members[0]}}
+	req := &ChannelRequest{Members: members, Invites: []string{members[0].UserID}}
 	resp, err := c.CreateChannel(ctx, "team", randomString(12), randomUser(t, c).ID, req)
 
 	require.NoError(t, err, "create channel")
-	_, err = resp.Channel.AcceptInvite(ctx, members[0], &Message{Text: "accepted", User: &User{ID: members[0]}})
+	_, err = resp.Channel.AcceptInvite(ctx, members[0].UserID, &Message{Text: "accepted", User: &User{ID: members[0].UserID}})
 	require.NoError(t, err, "accept invite")
 }
 
@@ -640,16 +640,16 @@ func TestChannel_RejectInvite(t *testing.T) {
 	ctx := context.Background()
 	users := randomUsers(t, c, 5)
 
-	members := make([]string, 0, len(users))
+	members := make([]ChannelMember, 0, len(users))
 	for i := range users {
-		members = append(members, users[i].ID)
+		members = append(members, ChannelMember{UserID: users[i].ID})
 	}
 
-	req := &ChannelRequest{Members: members, Invites: []string{members[0]}}
+	req := &ChannelRequest{Members: members, Invites: []string{members[0].UserID}}
 	resp, err := c.CreateChannel(ctx, "team", randomString(12), randomUser(t, c).ID, req)
 
 	require.NoError(t, err, "create channel")
-	_, err = resp.Channel.RejectInvite(ctx, members[0], &Message{Text: "rejected", User: &User{ID: members[0]}})
+	_, err = resp.Channel.RejectInvite(ctx, members[0].UserID, &Message{Text: "rejected", User: &User{ID: members[0].UserID}})
 	require.NoError(t, err, "reject invite")
 }
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -137,11 +137,14 @@ func TestChannel_AddMembers(t *testing.T) {
 
 	assert.Empty(t, ch.Members, "members are empty")
 
-	user := randomUser(t, c)
+	user := randomUsersChannelMember(t, c, 1)
 
-	msg := &Message{Text: "some members", User: &User{ID: user.ID}}
+	msg := &Message{
+		Text: "some members",
+		User: &User{ID: user[0].UserID},
+	}
 	_, err = ch.AddMembers(ctx,
-		[]string{user.ID},
+		user,
 		AddMembersWithMessage(msg),
 		AddMembersWithHideHistory(),
 	)
@@ -149,7 +152,7 @@ func TestChannel_AddMembers(t *testing.T) {
 
 	// refresh channel state
 	require.NoError(t, ch.refresh(ctx), "refresh channel")
-	assert.Equal(t, user.ID, ch.Members[0].User.ID, "members contain user id")
+	assert.Equal(t, user[0].UserID, ch.Members[0].User.ID, "members contain user id")
 }
 
 func TestChannel_AssignRoles(t *testing.T) {
@@ -185,9 +188,11 @@ func TestChannel_QueryMembers(t *testing.T) {
 
 	for _, name := range names {
 		id := prefix + name
-		_, err := c.UpsertUser(ctx, &User{ID: id, Name: id})
+		_, err := c.UpsertUser(ctx, &User{ID: id, Name: name})
 		require.NoError(t, err)
-		_, err = ch.AddMembers(ctx, []string{id})
+		_, err = ch.AddMembers(ctx, []ChannelMember{
+			{UserID: id, User: &User{ID: id, Name: name}},
+		})
 		require.NoError(t, err)
 	}
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -188,10 +188,10 @@ func TestChannel_QueryMembers(t *testing.T) {
 
 	for _, name := range names {
 		id := prefix + name
-		_, err := c.UpsertUser(ctx, &User{ID: id, Name: name})
+		_, err := c.UpsertUser(ctx, &User{ID: id, Name: id})
 		require.NoError(t, err)
 		_, err = ch.AddMembers(ctx, []ChannelMember{
-			{UserID: id, User: &User{ID: id, Name: name}},
+			{UserID: id, User: &User{ID: id, Name: id}},
 		})
 		require.NoError(t, err)
 	}

--- a/client.go
+++ b/client.go
@@ -19,15 +19,14 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 const (
 	// DefaultBaseURL is the default base URL for the stream chat api.
 	// It works like CDN style and connects you to the closest production server.
 	// By default, there is no real reason to change it. Use it only if you know what you are doing.
-	// DefaultBaseURL = "https://chat.stream-io-api.com"
-	DefaultBaseURL = "http://localhost:3030"
+	DefaultBaseURL = "https://chat.stream-io-api.com"
 	defaultTimeout = 6 * time.Second
 )
 

--- a/client.go
+++ b/client.go
@@ -19,14 +19,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 const (
 	// DefaultBaseURL is the default base URL for the stream chat api.
 	// It works like CDN style and connects you to the closest production server.
 	// By default, there is no real reason to change it. Use it only if you know what you are doing.
-	DefaultBaseURL = "https://chat.stream-io-api.com"
+	// DefaultBaseURL = "https://chat.stream-io-api.com"
+	DefaultBaseURL = "http://localhost:3030"
 	defaultTimeout = 6 * time.Second
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -19,14 +19,14 @@ func initClient(t *testing.T) *Client {
 	return c
 }
 
-func initChannel(t *testing.T, c *Client, membersID ...string) *Channel {
+func initChannel(t *testing.T, c *Client, users ...*User) *Channel {
 	t.Helper()
 
 	owner := randomUser(t, c)
 	ctx := context.Background()
-	members := make([]ChannelMember, len(membersID))
-	for _, member := range membersID {
-		members = append(members, ChannelMember{UserID: member})
+	var members []ChannelMember
+	for _, member := range users {
+		members = append(members, ChannelMember{UserID: member.ID, User: member})
 	}
 	resp, err := c.CreateChannelWithMembers(ctx, "team", randomString(12), owner.ID, members...)
 	require.NoError(t, err, "create channel")

--- a/client_test.go
+++ b/client_test.go
@@ -24,8 +24,11 @@ func initChannel(t *testing.T, c *Client, membersID ...string) *Channel {
 
 	owner := randomUser(t, c)
 	ctx := context.Background()
-
-	resp, err := c.CreateChannelWithMembers(ctx, "team", randomString(12), owner.ID, membersID...)
+	members := make([]ChannelMember, len(membersID))
+	for _, member := range membersID {
+		members = append(members, ChannelMember{UserID: member})
+	}
+	resp, err := c.CreateChannelWithMembers(ctx, "team", randomString(12), owner.ID, members...)
 	require.NoError(t, err, "create channel")
 
 	t.Cleanup(func() {

--- a/draft_test.go
+++ b/draft_test.go
@@ -166,7 +166,7 @@ func TestClient_QueryDraftsWithFilters(t *testing.T) {
 
 	// Create a channel
 	user := randomUser(t, c)
-	channel1 := initChannel(t, c, user.ID)
+	channel1 := initChannel(t, c, user)
 
 	// Create a draft message
 	draft1 := &messageRequestMessage{
@@ -176,7 +176,7 @@ func TestClient_QueryDraftsWithFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a second channel
-	channel2 := initChannel(t, c, user.ID)
+	channel2 := initChannel(t, c, user)
 
 	// Create a draft in the second channel
 	draft2 := &messageRequestMessage{

--- a/message_history_test.go
+++ b/message_history_test.go
@@ -14,7 +14,7 @@ func TestMessageHistory(t *testing.T) {
 	user1 := users[0]
 	user2 := users[1]
 
-	ch := initChannel(t, client, user1.ID)
+	ch := initChannel(t, client, user1)
 
 	ctx := context.Background()
 	initialText := "initial text"

--- a/message_test.go
+++ b/message_test.go
@@ -12,7 +12,7 @@ import (
 func TestClient_TranslateMessage(t *testing.T) {
 	c := initClient(t)
 	u := randomUser(t, c)
-	ch := initChannel(t, c, u.ID)
+	ch := initChannel(t, c, u)
 	ctx := context.Background()
 
 	msg := &Message{Text: "test message"}
@@ -30,7 +30,7 @@ func TestClient_SendMessage(t *testing.T) {
 
 	ctx := context.Background()
 
-	ch := initChannel(t, c, user.ID)
+	ch := initChannel(t, c, user)
 	resp1, err := c.CreateChannel(ctx, ch.Type, ch.ID, user.ID, nil)
 	require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func TestClient_SendMessage_Pending(t *testing.T) {
 
 	ctx := context.Background()
 
-	ch := initChannel(t, c, user.ID)
+	ch := initChannel(t, c, user)
 	resp1, err := c.CreateChannel(ctx, ch.Type, ch.ID, user.ID, nil)
 	require.NoError(t, err)
 
@@ -75,7 +75,7 @@ func TestClient_SendMessage_WithPendingFalse(t *testing.T) {
 
 	ctx := context.Background()
 
-	ch := initChannel(t, c, user.ID)
+	ch := initChannel(t, c, user)
 	resp1, err := c.CreateChannel(ctx, ch.Type, ch.ID, user.ID, nil)
 	require.NoError(t, err)
 
@@ -99,7 +99,7 @@ func TestClient_SendMessage_SkipEnrichURL(t *testing.T) {
 
 	ctx := context.Background()
 
-	ch := initChannel(t, c, user.ID)
+	ch := initChannel(t, c, user)
 	resp1, err := c.CreateChannel(ctx, ch.Type, ch.ID, user.ID, nil)
 	require.NoError(t, err)
 
@@ -120,7 +120,7 @@ func TestClient_PinMessage(t *testing.T) {
 	userB := randomUser(t, c)
 	ctx := context.Background()
 
-	ch := initChannel(t, c, userA.ID, userB.ID)
+	ch := initChannel(t, c, userA, userB)
 	resp1, err := c.CreateChannel(ctx, ch.Type, ch.ID, userA.ID, nil)
 	require.NoError(t, err)
 
@@ -174,7 +174,7 @@ func TestClient_SendMessage_KeepChannelHidden(t *testing.T) {
 
 	ctx := context.Background()
 
-	ch := initChannel(t, c, user.ID)
+	ch := initChannel(t, c, user)
 	resp, err := c.CreateChannel(ctx, ch.Type, ch.ID, user.ID, nil)
 	require.NoError(t, err)
 

--- a/query_test.go
+++ b/query_test.go
@@ -121,7 +121,7 @@ func TestClient_Search(t *testing.T) {
 
 	user1, user2 := randomUser(t, c), randomUser(t, c)
 
-	ch := initChannel(t, c, user1.ID, user2.ID)
+	ch := initChannel(t, c, user1, user2)
 
 	text := randomString(10)
 

--- a/thread_test.go
+++ b/thread_test.go
@@ -31,7 +31,7 @@ func TestClient_QueryThreads(t *testing.T) {
 			PagerRequest: PagerRequest{
 				Limit: &limit,
 			},
-			UserID: membersID[0],
+			UserID: membersID[0].ID,
 		}
 
 		resp, err := c.QueryThreads(ctx, query)
@@ -76,7 +76,7 @@ func TestClient_QueryThreads(t *testing.T) {
 			PagerRequest: PagerRequest{
 				Limit: &limit,
 			},
-			UserID: membersID[0],
+			UserID: membersID[0].ID,
 		}
 
 		resp, err := c.QueryThreads(ctx, query)
@@ -105,7 +105,7 @@ func TestClient_QueryThreads(t *testing.T) {
 				Limit: &limit,
 				Next:  resp.Next,
 			},
-			UserID: membersID[0],
+			UserID: membersID[0].ID,
 		}
 
 		resp, err = c.QueryThreads(ctx, query2)
@@ -120,8 +120,8 @@ func TestClient_QueryThreads(t *testing.T) {
 }
 
 // testThreadSetup creates a channel with members and returns necessary test data
-func testThreadSetup(t *testing.T, c *Client, numMembers int) ([]string, *Channel, *MessageResponse, *MessageResponse) {
-	membersID := randomUsersID(t, c, numMembers)
+func testThreadSetup(t *testing.T, c *Client, numMembers int) ([]*User, *Channel, *MessageResponse, *MessageResponse) {
+	membersID := randomUsers(t, c, numMembers)
 	ch := initChannel(t, c, membersID...)
 
 	// Create a parent message

--- a/thread_test.go
+++ b/thread_test.go
@@ -13,7 +13,7 @@ func TestClient_QueryThreads(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("basic query", func(t *testing.T) {
-		membersID, ch, parentMsg, replyMsg := testThreadSetup(t, c, 3)
+		members, ch, parentMsg, replyMsg := testThreadSetup(t, c, 3)
 
 		limit := 10
 		query := &QueryThreadsRequest{
@@ -31,7 +31,7 @@ func TestClient_QueryThreads(t *testing.T) {
 			PagerRequest: PagerRequest{
 				Limit: &limit,
 			},
-			UserID: membersID[0].ID,
+			UserID: members[0].ID,
 		}
 
 		resp, err := c.QueryThreads(ctx, query)
@@ -47,7 +47,7 @@ func TestClient_QueryThreads(t *testing.T) {
 	})
 
 	t.Run("with pagination", func(t *testing.T) {
-		membersID, ch, parentMsg1, replyMsg1 := testThreadSetup(t, c, 3)
+		members, ch, parentMsg1, replyMsg1 := testThreadSetup(t, c, 3)
 		limit := 1
 
 		// Create a second thread
@@ -76,7 +76,7 @@ func TestClient_QueryThreads(t *testing.T) {
 			PagerRequest: PagerRequest{
 				Limit: &limit,
 			},
-			UserID: membersID[0].ID,
+			UserID: members[0].ID,
 		}
 
 		resp, err := c.QueryThreads(ctx, query)
@@ -105,7 +105,7 @@ func TestClient_QueryThreads(t *testing.T) {
 				Limit: &limit,
 				Next:  resp.Next,
 			},
-			UserID: membersID[0].ID,
+			UserID: members[0].ID,
 		}
 
 		resp, err = c.QueryThreads(ctx, query2)
@@ -121,8 +121,8 @@ func TestClient_QueryThreads(t *testing.T) {
 
 // testThreadSetup creates a channel with members and returns necessary test data
 func testThreadSetup(t *testing.T, c *Client, numMembers int) ([]*User, *Channel, *MessageResponse, *MessageResponse) {
-	membersID := randomUsers(t, c, numMembers)
-	ch := initChannel(t, c, membersID...)
+	members := randomUsers(t, c, numMembers)
+	ch := initChannel(t, c, members...)
 
 	// Create a parent message
 	parentMsg, err := ch.SendMessage(context.Background(), &Message{Text: "Parent message for thread"}, ch.CreatedBy.ID)
@@ -135,7 +135,7 @@ func testThreadSetup(t *testing.T, c *Client, numMembers int) ([]*User, *Channel
 	}, ch.CreatedBy.ID)
 	require.NoError(t, err, "send reply message")
 
-	return membersID, ch, parentMsg, replyMsg
+	return members, ch, parentMsg, replyMsg
 }
 
 // assertThreadData validates common thread data fields

--- a/unread_counts_test.go
+++ b/unread_counts_test.go
@@ -11,7 +11,7 @@ import (
 func TestUnreadCounts(t *testing.T) {
 	c := initClient(t)
 	user := randomUser(t, c)
-	ch := initChannel(t, c, user.ID)
+	ch := initChannel(t, c, user)
 
 	ctx := context.Background()
 	msg := &Message{Text: "test message"}
@@ -51,7 +51,7 @@ func TestUnreadCountsBatch(t *testing.T) {
 	c := initClient(t)
 	user1 := randomUser(t, c)
 	user2 := randomUser(t, c)
-	ch := initChannel(t, c, user1.ID, user2.ID)
+	ch := initChannel(t, c, user1, user2)
 
 	ctx := context.Background()
 	msg := &Message{Text: "test message"}

--- a/utils_test.go
+++ b/utils_test.go
@@ -125,7 +125,7 @@ func randomUsersChannelMember(t *testing.T, c *Client, n int) []ChannelMember {
 	users := randomUsers(t, c, n)
 	members := make([]ChannelMember, n)
 	for i, u := range users {
-		members[i] = ChannelMember{UserID: u.ID}
+		members[i] = ChannelMember{UserID: u.ID, User: u}
 	}
 	return members
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -119,6 +119,17 @@ func randomUsersID(t *testing.T, c *Client, n int) []string {
 	return ids
 }
 
+func randomUsersChannelMember(t *testing.T, c *Client, n int) []ChannelMember {
+	t.Helper()
+
+	users := randomUsers(t, c, n)
+	members := make([]ChannelMember, n)
+	for i, u := range users {
+		members[i] = ChannelMember{UserID: u.ID}
+	}
+	return members
+}
+
 func randomString(n int) string {
 	bytes := make([]byte, n)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

The backend already support pass the ChannelMember instead of only the ID, this change aim change to use the whole ChannelMember for create/update channel requests
