### PR TITLE
Replace deprecated ioutil.TempFile with os.CreateTemp

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -203,7 +202,7 @@ func (c *Client) sendFile(ctx context.Context, link string, opts SendFileRequest
 		return nil, errors.New("user is nil")
 	}
 
-	tmpfile, err := ioutil.TempFile("", opts.FileName)
+	tmpfile, err := os.CreateTemp("", opts.FileName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Replaces the use of the deprecated `ioutil.TempFile` function with the new `os.CreateTemp` in the `sendFile` helper. This aligns the codebase with Go 1.21+ conventions and removes reliance on the deprecated `ioutil` package.

### Test Results

Confirmed that the `sendFile` functionality continues to work as expected after this change:

```shell

$ go test -timeout 30s -run ^TestChannel_SendFile$ github.com/GetStream/stream-chat-go/v7
ok      github.com/GetStream/stream-chat-go/v7  2.623s

$ go test -timeout 30s -run ^TestChannel_SendImage$ github.com/GetStream/stream-chat-go/v7
ok      github.com/GetStream/stream-chat-go/v7  0.576s
```
