### PR TITLE
[CHA-2693] Fix ExportUser response parsing

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -129,3 +129,61 @@ func TestFlattenExtraData(t *testing.T) {
 		require.Equal(t, "value1", m["field1"])
 	})
 }
+
+func TestExportUserResponse_UnmarshalJSON(t *testing.T) {
+	// This is the actual response format returned by the API.
+	// Previously, ExportUserResponse embedded *User directly, which caused
+	// User.UnmarshalJSON to consume the entire response body, losing the
+	// user, messages, and reactions data.
+	apiResponse := `{
+		"user": {
+			"id": "103415720",
+			"name": "Batman",
+			"language": "",
+			"role": "user",
+			"teams": [],
+			"created_at": "2025-05-06T19:41:07.894092Z",
+			"updated_at": "2025-05-06T20:15:52.812595Z",
+			"banned": false,
+			"online": false,
+			"last_active": "2026-03-10T14:09:24.664584Z",
+			"blocked_user_ids": [],
+			"shadow_banned": false,
+			"invisible": false
+		},
+		"messages": [
+			{
+				"id": "msg1",
+				"cid": "messaging:general",
+				"text": "Hello world",
+				"user": {"id": "103415720"},
+				"user_id": "103415720"
+			}
+		],
+		"reactions": [
+			{
+				"message_id": "msg1",
+				"user_id": "103415720",
+				"type": "like"
+			}
+		],
+		"duration": "117.63ms"
+	}`
+
+	var resp ExportUserResponse
+	err := json.Unmarshal([]byte(apiResponse), &resp)
+	require.NoError(t, err)
+
+	require.NotNil(t, resp.User)
+	require.Equal(t, "103415720", resp.User.ID)
+	require.Equal(t, "Batman", resp.User.Name)
+	require.Equal(t, "user", resp.User.Role)
+
+	require.Len(t, resp.Messages, 1)
+	require.Equal(t, "msg1", resp.Messages[0].ID)
+	require.Equal(t, "Hello world", resp.Messages[0].Text)
+
+	require.Len(t, resp.Reactions, 1)
+	require.Equal(t, "msg1", resp.Reactions[0].MessageID)
+	require.Equal(t, "like", resp.Reactions[0].Type)
+}

--- a/user.go
+++ b/user.go
@@ -343,7 +343,9 @@ func (c *Client) CreateGuestUser(ctx context.Context, user *User) (*GuestUserRes
 }
 
 type ExportUserResponse struct {
-	*User
+	User      *User       `json:"user"`
+	Messages  []*Message  `json:"messages"`
+	Reactions []*Reaction `json:"reactions"`
 	Response
 }
 


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/CHA-2693/investigate-go-sdk-bug-causing-parsing-error-in-exportuser-api

## Summary
- **Fix `ExportUserResponse` struct** to match the actual API response format. The struct previously embedded `*User` directly, which caused `User.UnmarshalJSON` to consume the entire response body — user data was never properly extracted and messages/reactions were completely lost.
- **Add missing `Messages` and `Reactions` fields** that the API returns but the SDK was silently discarding.

## Problem

The `ExportUser` API returns:
```json
{
    "user": {"id": "...", "name": "..."},
    "messages": [...],
    "reactions": [...],
    "duration": "..."
}
```

The old struct:
```go
type ExportUserResponse struct {
    *User    // embedded — promotes UnmarshalJSON to the whole response
    Response
}
```

Because `*User` has a custom `UnmarshalJSON`, embedding it caused the **entire** response body to be passed to `User.UnmarshalJSON`. This meant:
1. User fields (nested under `"user"` key) were never populated — everything went into `User.ExtraData`
2. `Messages` and `Reactions` were silently lost (no struct fields existed for them)

The fix changes to named fields matching the API response:
```go
type ExportUserResponse struct {
    User      *User       `json:"user"`
    Messages  []*Message  `json:"messages"`
    Reactions []*Reaction `json:"reactions"`
    Response
}
```

## Breaking change

This is a **breaking change** for any code that accessed the user via `resp.ID`, `resp.Name`, etc. (promoted fields from the embedded `*User`). Callers must now use `resp.User.ID`, `resp.User.Name`, etc. However, the old code was fundamentally broken (user fields were always empty), so any existing callers were already getting incorrect results.

## Other SDKs

```
  ┌───────────────────────┬─────────────────┬────────────────────────────────────────────────────────────────────────────────────┐
  │          SDK          │  Has the bug?   │                                      Details                                       │
  ├───────────────────────┼─────────────────┼────────────────────────────────────────────────────────────────────────────────────┤
  │ Go                    │ Yes (now fixed) │ ExportUserResponse embedded *User directly, losing all fields                      │
  ├───────────────────────┼─────────────────┼────────────────────────────────────────────────────────────────────────────────────┤
  │ JavaScript/TypeScript │ No              │ Response type correctly defines user, messages, reactions inline                   │
  ├───────────────────────┼─────────────────┼────────────────────────────────────────────────────────────────────────────────────┤
  │ Python                │ No              │ Returns generic dict-based StreamResponse — all keys accessible dynamically        │
  ├───────────────────────┼─────────────────┼────────────────────────────────────────────────────────────────────────────────────┤
  │ Java                  │ No              │ UserExportResponse correctly declares user, messages, reactions with @JsonProperty │
  ├───────────────────────┼─────────────────┼────────────────────────────────────────────────────────────────────────────────────┤
  │ .NET                  │ No              │ ExportedUser model explicitly declares User, Messages, Reactions                   │
  ├───────────────────────┼─────────────────┼────────────────────────────────────────────────────────────────────────────────────┤
  │ Ruby                  │ No              │ Returns generic Hash-based StreamResponse — all keys accessible dynamically        │
  └───────────────────────┴─────────────────┴────────────────────────────────────────────────────────────────────────────────────┘

```

## Checklist
- [x] Unit test added (`TestExportUserResponse_UnmarshalJSON`)
- [x] `go build` passes
- [x] `go vet` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)