### PR TITLE
[MOD2-818] Add delete_reactions support for ban user

### DIFF
--- a/ban.go
+++ b/ban.go
@@ -153,6 +153,7 @@ type banOptions struct {
 	BannedBy              string `json:"user_id"`
 	Shadow                bool   `json:"shadow"`
 	BanFromFutureChannels bool   `json:"ban_from_future_channels,omitempty"`
+	DeleteReactions       bool   `json:"delete_reactions,omitempty"`
 
 	// ID and Type of the channel when acting on a channel member.
 	ID   string `json:"id"`
@@ -199,6 +200,14 @@ func banFromChannel(_type, id string) func(*banOptions) {
 func BanWithBanFromFutureChannels() func(*banOptions) {
 	return func(opt *banOptions) {
 		opt.BanFromFutureChannels = true
+	}
+}
+
+// BanWithDeleteReactions when set to true, all reactions by the banned user
+// on other users' messages will be deleted.
+func BanWithDeleteReactions() func(*banOptions) {
+	return func(opt *banOptions) {
+		opt.DeleteReactions = true
 	}
 }
 

--- a/ban_test.go
+++ b/ban_test.go
@@ -182,6 +182,19 @@ func TestQueryFutureChannelBans(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBanWithDeleteReactions(t *testing.T) {
+	c := initClient(t)
+	target := randomUser(t, c)
+	user := randomUser(t, c)
+	ctx := context.Background()
+
+	_, err := c.BanUser(ctx, target.ID, user.ID, BanWithDeleteReactions())
+	require.NoError(t, err)
+
+	_, err = c.UnBanUser(ctx, target.ID)
+	require.NoError(t, err)
+}
+
 func ExampleClient_BanUser() {
 	client, _ := NewClient("XXXX", "XXXX")
 	ctx := context.Background()


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/MOD2-818

## Summary
Adds `BanWithDeleteReactions()` option for the ban API that removes all reactions by the banned user on other users' messages when banning.

This corresponds to the backend change in https://github.com/GetStream/chat/pull/12495 which added `delete_reactions` support to the `POST moderation/ban` endpoint.

## Changes
- Added `DeleteReactions` field to `banOptions` struct
- Added `BanWithDeleteReactions()` functional option
- Added `TestBanWithDeleteReactions` test

## Checklist
- [x] The changed code has been covered with unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)