### PR TITLE
feat(webhooks): verifyAndParse* API for compressed payloads (CHA-3071)

### DIFF
--- a/client.go
+++ b/client.go
@@ -334,3 +334,33 @@ func (c *Client) UpdateChannelsBatch(ctx context.Context, options *ChannelsBatch
 func (c *Client) ChannelBatchUpdater() *ChannelBatchUpdater {
 	return &ChannelBatchUpdater{client: c}
 }
+
+// VerifyAndParseSqs is the client-bound form of the package-level
+// helper. Signature is variadic to make verification opt-in: omit it
+// for the default AWS-transport-is-the-auth-layer behavior (decode +
+// parse), or pass exactly one signature string to also run the HMAC
+// check against the client's API secret.
+func (c *Client) VerifyAndParseSqs(body string, signature ...string) (*Event, error) {
+	switch len(signature) {
+	case 0:
+		return VerifyAndParseSqs(body, "", "")
+	case 1:
+		return VerifyAndParseSqs(body, signature[0], string(c.apiSecret))
+	default:
+		return nil, fmt.Errorf("VerifyAndParseSqs accepts at most one signature argument: %w", ErrInvalidWebhook)
+	}
+}
+
+// VerifyAndParseSns is the client-bound form of the package-level
+// helper. Signature is variadic; see VerifyAndParseSqs for the
+// behavior matrix.
+func (c *Client) VerifyAndParseSns(notificationBody string, signature ...string) (*Event, error) {
+	switch len(signature) {
+	case 0:
+		return VerifyAndParseSns(notificationBody, "", "")
+	case 1:
+		return VerifyAndParseSns(notificationBody, signature[0], string(c.apiSecret))
+	default:
+		return nil, fmt.Errorf("VerifyAndParseSns accepts at most one signature argument: %w", ErrInvalidWebhook)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -335,32 +335,17 @@ func (c *Client) ChannelBatchUpdater() *ChannelBatchUpdater {
 	return &ChannelBatchUpdater{client: c}
 }
 
-// VerifyAndParseSqs is the client-bound form of the package-level
-// helper. Signature is variadic to make verification opt-in: omit it
-// for the default AWS-transport-is-the-auth-layer behavior (decode +
-// parse), or pass exactly one signature string to also run the HMAC
-// check against the client's API secret.
-func (c *Client) VerifyAndParseSqs(body string, signature ...string) (*Event, error) {
-	switch len(signature) {
-	case 0:
-		return VerifyAndParseSqs(body, "", "")
-	case 1:
-		return VerifyAndParseSqs(body, signature[0], string(c.apiSecret))
-	default:
-		return nil, fmt.Errorf("VerifyAndParseSqs accepts at most one signature argument: %w", ErrInvalidWebhook)
-	}
+// ParseSqs is the client-bound form of the package-level ParseSqs
+// helper. SQS deliveries from Stream are not HMAC-signed (the queue
+// itself is the authentication layer via IAM), so this is a pure
+// decode-and-parse call.
+func (c *Client) ParseSqs(body string) (*Event, error) {
+	return ParseSqs(body)
 }
 
-// VerifyAndParseSns is the client-bound form of the package-level
-// helper. Signature is variadic; see VerifyAndParseSqs for the
-// behavior matrix.
-func (c *Client) VerifyAndParseSns(notificationBody string, signature ...string) (*Event, error) {
-	switch len(signature) {
-	case 0:
-		return VerifyAndParseSns(notificationBody, "", "")
-	case 1:
-		return VerifyAndParseSns(notificationBody, signature[0], string(c.apiSecret))
-	default:
-		return nil, fmt.Errorf("VerifyAndParseSns accepts at most one signature argument: %w", ErrInvalidWebhook)
-	}
+// ParseSns is the client-bound form of the package-level ParseSns
+// helper. SNS deliveries from Stream are not HMAC-signed (AWS signs
+// the notification envelope), so this is a pure decode-and-parse call.
+func (c *Client) ParseSns(body string) (*Event, error) {
+	return ParseSns(body)
 }

--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package stream_chat
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"crypto/hmac"
@@ -152,12 +151,13 @@ func (c *Client) createToken(claims jwt.Claims) (string, error) {
 }
 
 // VerifyWebhook validates if hmac signature is correct for message body.
+// The comparison is constant-time.
 func (c *Client) VerifyWebhook(body, signature []byte) (valid bool) {
 	mac := hmac.New(crypto.SHA256.New, c.apiSecret)
 	_, _ = mac.Write(body)
 
-	expectedMAC := hex.EncodeToString(mac.Sum(nil))
-	return bytes.Equal(signature, []byte(expectedMAC))
+	expectedMAC := []byte(hex.EncodeToString(mac.Sum(nil)))
+	return hmac.Equal(expectedMAC, signature)
 }
 
 // this makes possible to set content type.

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -131,16 +131,32 @@ All webhook failure paths (`VerifyAndParseWebhook`, `VerifyAndParseSqs`, `Verify
 
 #### SQS / SNS firehose
 
-When the same events are delivered through SQS or SNS, Stream additionally base64-wraps the bytes so the message stays valid UTF-8 over the queue. Use the firehose helpers - they base64-decode, gunzip when needed, then verify and parse in the correct order:
+When the same events are delivered through SQS or SNS, Stream additionally base64-wraps the bytes so the message stays valid UTF-8 over the queue. Use the firehose helpers - they base64-decode, gunzip when needed, then parse in the correct order:
 
 ```go
-// messageBody: the SQS Body / SNS Message field as a string
-// signature: value from the X-Signature message attribute
-event, err := client.VerifyAndParseSqs(messageBody, signature) // SQS
-event, err = client.VerifyAndParseSns(messageBody, signature)  // SNS
+// messageBody:   the SQS message Body as a string
+// envelopeBody:  the raw SNS HTTP notification body (or the pre-extracted Message field)
+event, err := client.VerifyAndParseSqs(messageBody)   // SQS
+event, err = client.VerifyAndParseSns(envelopeBody)   // SNS
 ```
 
-Stateless package-level forms are also available for callers that do not hold a `*Client`: `stream.VerifyAndParseWebhook(body, signature, secret)`, `stream.VerifyAndParseSqs(messageBody, signature, secret)`, `stream.VerifyAndParseSns(message, signature, secret)`.
+Stream does not ship an `X-Signature` on SQS or SNS deliveries: those transports ride AWS-internal infrastructure (IAM-authenticated queues and AWS-signed SNS notifications), which is the auth layer. The signature argument is optional and only needed if you have set up out-of-band signing in front of these helpers; in that case pass it as a second argument and the client will HMAC-verify against its own API secret:
+
+```go
+event, err := client.VerifyAndParseSqs(messageBody, signature) // opt-in HMAC verification
+event, err = client.VerifyAndParseSns(envelopeBody, signature)
+```
+
+Stateless package-level forms are also available for callers that do not hold a `*Client`. Pass empty strings for `signature` and `secret` to skip verification, or pass both to run the HMAC check:
+
+```go
+event, err := stream.VerifyAndParseWebhook(body, signature, secret)
+event, err = stream.VerifyAndParseSqs(messageBody, "", "")          // skip verification
+event, err = stream.VerifyAndParseSqs(messageBody, signature, secret) // verify
+event, err = stream.VerifyAndParseSns(envelopeBody, "", "")
+```
+
+Passing exactly one of `signature` or `secret` returns an error wrapping `stream.ErrInvalidWebhook` with the message `"signature and secret must both be provided"` - it is treated as a programmer error rather than a silent skip.
 
 ## Webhook types
 

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -103,37 +103,42 @@ Before enabling compression, make sure that:
 * If you don't use an official SDK, make sure that your code supports receiving compressed payloads
 * The payload signature check is done on the **uncompressed** payload
 
-Use `VerifyAndDecodeWebhook` to decompress and verify the signature in a single call. The signature is always computed over the uncompressed JSON, so this method works whether compression is on or off.
+Use `VerifyAndParseWebhook` to decompress, verify the signature, and parse the event in a single call. The body is detected as gzip via its 2-byte magic header (per RFC 1952), so the call works whether your HTTP framework already decompressed the body, the `Content-Encoding` header was stripped, or compression is disabled. The signature is always computed over the uncompressed JSON.
 
 ```go
 client, _ := stream.NewClient(APIKey, APISecret)
 
-// signature comes from the X-Signature header
-// contentEncoding comes from the Content-Encoding header (may be "" if your
-// HTTP framework already decompressed the body or compression is disabled)
-payload, err := client.VerifyAndDecodeWebhook(body, signature, contentEncoding, "")
+// body: raw request body bytes (do not parse JSON before this call)
+// signature: value of the X-Signature header
+event, err := client.VerifyAndParseWebhook(body, signature)
 if err != nil {
     if errors.Is(err, stream.ErrInvalidWebhookSignature) {
         // signature did not match - reject the request
     }
-    // decompression error or unsupported encoding
+    // decompression or JSON parse error
     return
 }
-// payload is the raw JSON body the server signed
+// event is *stream.Event - inspect event.Type, event.Message, etc.
 ```
 
-If you want to handle decompression yourself, use the lower-level `DecompressWebhookBody` and then call `VerifyWebhook` on the result.
+If you want to drive the steps yourself, the package exposes the building blocks:
+
+* `stream.UngzipPayload(body []byte) ([]byte, error)` - returns body unchanged unless it begins with the gzip magic, in which case it is inflated.
+* `stream.VerifySignature(body []byte, signature, secret string) bool` - constant-time HMAC-SHA256 check against the uncompressed bytes.
+* `stream.ParseEvent(payload []byte) (*stream.Event, error)` - JSON decode into a typed event.
 
 #### SQS / SNS firehose
 
-When the same compressed events are delivered through SQS or SNS, Stream additionally base64-wraps the bytes so the message stays valid UTF-8 over the queue. Pass `"base64"` as the `payloadEncoding` argument and the helper handles both layers in the correct order (base64 first, then gunzip):
+When the same events are delivered through SQS or SNS, Stream additionally base64-wraps the bytes so the message stays valid UTF-8 over the queue. Use the firehose helpers - they base64-decode, gunzip when needed, then verify and parse in the correct order:
 
 ```go
-// body: SQS Body / SNS Message bytes
-// signature: value from the message attribute
-// contentEncoding: "gzip" when compression is enabled, "" otherwise
-payload, err := client.VerifyAndDecodeWebhook(body, signature, contentEncoding, "base64")
+// messageBody: the SQS Body / SNS Message field as a string
+// signature: value from the X-Signature message attribute
+event, err := client.VerifyAndParseSqs(messageBody, signature) // SQS
+event, err = client.VerifyAndParseSns(messageBody, signature)  // SNS
 ```
+
+Stateless package-level forms are also available for callers that do not hold a `*Client`: `stream.VerifyAndParseWebhook(body, signature, secret)`, `stream.VerifyAndParseSqs(messageBody, signature, secret)`, `stream.VerifyAndParseSns(message, signature, secret)`.
 
 ## Webhook types
 

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -126,7 +126,7 @@ If you want to drive the steps yourself, the package exposes the building blocks
 * `stream.VerifySignature(body []byte, signature, secret string) error` - constant-time HMAC-SHA256 check against the uncompressed bytes; returns `nil` on match or an error wrapping `stream.ErrInvalidWebhook` on mismatch.
 * `stream.ParseEvent(payload []byte) (*stream.Event, error)` - JSON decode into a typed event.
 
-All webhook failure paths (`VerifyAndParseWebhook`, `VerifyAndParseSqs`, `VerifyAndParseSns`, `VerifySignature`, `GunzipPayload`, `DecodeSqsPayload`, `ParseEvent`) wrap a single sentinel `stream.ErrInvalidWebhook`, so a single `errors.Is(err, stream.ErrInvalidWebhook)` check covers signature mismatch, base64 decode, gzip decompression, and JSON parse failures. To distinguish the failure mode, match a substring of the error message (`"signature mismatch"`, `"invalid base64 encoding"`, `"gzip decompression failed"`, `"invalid JSON payload"`).
+All webhook failure paths (`VerifyAndParseWebhook`, `ParseSqs`, `ParseSns`, `VerifySignature`, `GunzipPayload`, `DecodeSqsPayload`, `DecodeSnsPayload`, `ParseEvent`) wrap a single sentinel `stream.ErrInvalidWebhook`, so a single `errors.Is(err, stream.ErrInvalidWebhook)` check covers signature mismatch, base64 decode, gzip decompression, and JSON parse failures. To distinguish the failure mode, match a substring of the error message (`"signature mismatch"`, `"invalid base64 encoding"`, `"gzip decompression failed"`, `"invalid JSON payload"`).
 
 
 #### SQS / SNS firehose
@@ -134,29 +134,30 @@ All webhook failure paths (`VerifyAndParseWebhook`, `VerifyAndParseSqs`, `Verify
 When the same events are delivered through SQS or SNS, Stream additionally base64-wraps the bytes so the message stays valid UTF-8 over the queue. Use the firehose helpers - they base64-decode, gunzip when needed, then parse in the correct order:
 
 ```go
-// messageBody:   the SQS message Body as a string
-// envelopeBody:  the raw SNS HTTP notification body (or the pre-extracted Message field)
-event, err := client.VerifyAndParseSqs(messageBody)   // SQS
-event, err = client.VerifyAndParseSns(envelopeBody)   // SNS
+// messageBody:    the SQS message Body as a string
+// envelopeBody:   the raw SNS HTTP notification body (or the pre-extracted Message field)
+event, err := client.ParseSqs(messageBody)   // SQS
+event, err = client.ParseSns(envelopeBody)   // SNS
 ```
 
-Stream does not ship an `X-Signature` on SQS or SNS deliveries: those transports ride AWS-internal infrastructure (IAM-authenticated queues and AWS-signed SNS notifications), which is the auth layer. The signature argument is optional and only needed if you have set up out-of-band signing in front of these helpers; in that case pass it as a second argument and the client will HMAC-verify against its own API secret:
+`ParseSqs` and `ParseSns` are pure decode-and-parse helpers — there is no HMAC step. Stream does not ship an `X-Signature` on SQS or SNS deliveries: those transports ride AWS-internal infrastructure (IAM-authenticated queues and AWS-signed SNS notifications), which is the authentication layer. The HTTP webhook flow (`VerifyAndParseWebhook`) is unchanged and still HMAC-verifies the body against your API secret.
+
+Arguments:
+
+| Helper                  | Argument        | Description                                                                                  |
+| ----------------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `client.ParseSqs`       | `messageBody`   | The SQS message `Body` field as a string (base64-encoded, gzip-wrapped when compression is on). |
+| `client.ParseSns`       | `envelopeBody`  | The raw SNS HTTP notification body, or the pre-extracted `Message` field as a string.        |
+
+Stateless package-level forms are available for callers that do not hold a `*Client`:
 
 ```go
-event, err := client.VerifyAndParseSqs(messageBody, signature) // opt-in HMAC verification
-event, err = client.VerifyAndParseSns(envelopeBody, signature)
+event, err := stream.VerifyAndParseWebhook(body, signature, secret) // HTTP webhook: HMAC-verified
+event, err = stream.ParseSqs(messageBody)                            // SQS: decode + parse
+event, err = stream.ParseSns(envelopeBody)                           // SNS: unwrap + decode + parse
 ```
 
-Stateless package-level forms are also available for callers that do not hold a `*Client`. Pass empty strings for `signature` and `secret` to skip verification, or pass both to run the HMAC check:
-
-```go
-event, err := stream.VerifyAndParseWebhook(body, signature, secret)
-event, err = stream.VerifyAndParseSqs(messageBody, "", "")          // skip verification
-event, err = stream.VerifyAndParseSqs(messageBody, signature, secret) // verify
-event, err = stream.VerifyAndParseSns(envelopeBody, "", "")
-```
-
-Passing exactly one of `signature` or `secret` returns an error wrapping `stream.ErrInvalidWebhook` with the message `"signature and secret must both be provided"` - it is treated as a programmer error rather than a silent skip.
+Every failure (base64 decode, gzip inflate, JSON parse) wraps `stream.ErrInvalidWebhook`, so the same `errors.Is(err, stream.ErrInvalidWebhook)` check used for the HTTP webhook covers the firehose helpers as well.
 
 ## Webhook types
 

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -89,6 +89,51 @@ All webhook requests contain these headers:
 | X-Webhook-Attempt | Number of webhook request attempt starting from 1                                                                    | 1                                                                |
 | X-Api-Key         | Your application’s API key. Should be used to validate request signature                                             | a1b23cdefgh4                                                     |
 | X-Signature       | HMAC signature of the request body. See Signature section                                                            | ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb |
+| Content-Encoding  | Compression algorithm used for the body. Only set when payload compression is enabled (currently `gzip`)             | gzip                                                             |
+
+### Compressed webhook bodies
+
+GZIP compression can be enabled for hooks payloads from the Dashboard. Enabling compression reduces the payload size significantly (often 70–90% smaller) reducing your bandwidth usage on Stream. The computation overhead introduced by the decompression step is usually negligible and offset by the much smaller payload.
+
+When payload compression is enabled, webhook HTTP requests will include the `Content-Encoding: gzip` header and the request body will be compressed with GZIP. Some HTTP servers and middleware (Rails, Django, Laravel, Spring Boot, ASP.NET) handle this transparently and strip the header before your handler runs — in that case the body you see is already raw JSON.
+
+Before enabling compression, make sure that:
+
+* Your backend integration is using a recent version of our official SDKs with compression support
+* If you don't use an official SDK, make sure that your code supports receiving compressed payloads
+* The payload signature check is done on the **uncompressed** payload
+
+Use `VerifyAndDecodeWebhook` to decompress and verify the signature in a single call. The signature is always computed over the uncompressed JSON, so this method works whether compression is on or off.
+
+```go
+client, _ := stream.NewClient(APIKey, APISecret)
+
+// signature comes from the X-Signature header
+// contentEncoding comes from the Content-Encoding header (may be "" if your
+// HTTP framework already decompressed the body or compression is disabled)
+payload, err := client.VerifyAndDecodeWebhook(body, signature, contentEncoding, "")
+if err != nil {
+    if errors.Is(err, stream.ErrInvalidWebhookSignature) {
+        // signature did not match - reject the request
+    }
+    // decompression error or unsupported encoding
+    return
+}
+// payload is the raw JSON body the server signed
+```
+
+If you want to handle decompression yourself, use the lower-level `DecompressWebhookBody` and then call `VerifyWebhook` on the result.
+
+#### SQS / SNS firehose
+
+When the same compressed events are delivered through SQS or SNS, Stream additionally base64-wraps the bytes so the message stays valid UTF-8 over the queue. Pass `"base64"` as the `payloadEncoding` argument and the helper handles both layers in the correct order (base64 first, then gunzip):
+
+```go
+// body: SQS Body / SNS Message bytes
+// signature: value from the message attribute
+// contentEncoding: "gzip" when compression is enabled, "" otherwise
+payload, err := client.VerifyAndDecodeWebhook(body, signature, contentEncoding, "base64")
+```
 
 ## Webhook types
 

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -112,10 +112,9 @@ client, _ := stream.NewClient(APIKey, APISecret)
 // signature: value of the X-Signature header
 event, err := client.VerifyAndParseWebhook(body, signature)
 if err != nil {
-    if errors.Is(err, stream.ErrInvalidWebhookSignature) {
-        // signature did not match - reject the request
+    if errors.Is(err, stream.ErrInvalidWebhook) {
+        // reject the request - signature mismatch, base64/gzip decode, or JSON parse
     }
-    // decompression or JSON parse error
     return
 }
 // event is *stream.Event - inspect event.Type, event.Message, etc.
@@ -124,8 +123,11 @@ if err != nil {
 If you want to drive the steps yourself, the package exposes the building blocks:
 
 * `stream.GunzipPayload(body []byte) ([]byte, error)` - returns body unchanged unless it begins with the gzip magic, in which case it is inflated.
-* `stream.VerifySignature(body []byte, signature, secret string) bool` - constant-time HMAC-SHA256 check against the uncompressed bytes.
+* `stream.VerifySignature(body []byte, signature, secret string) error` - constant-time HMAC-SHA256 check against the uncompressed bytes; returns `nil` on match or an error wrapping `stream.ErrInvalidWebhook` on mismatch.
 * `stream.ParseEvent(payload []byte) (*stream.Event, error)` - JSON decode into a typed event.
+
+All webhook failure paths (`VerifyAndParseWebhook`, `VerifyAndParseSqs`, `VerifyAndParseSns`, `VerifySignature`, `GunzipPayload`, `DecodeSqsPayload`, `ParseEvent`) wrap a single sentinel `stream.ErrInvalidWebhook`, so a single `errors.Is(err, stream.ErrInvalidWebhook)` check covers signature mismatch, base64 decode, gzip decompression, and JSON parse failures. To distinguish the failure mode, match a substring of the error message (`"signature mismatch"`, `"invalid base64 encoding"`, `"gzip decompression failed"`, `"invalid JSON payload"`).
+
 
 #### SQS / SNS firehose
 

--- a/docs/webhooks/webhooks_overview/webhooks_overview.md
+++ b/docs/webhooks/webhooks_overview/webhooks_overview.md
@@ -123,7 +123,7 @@ if err != nil {
 
 If you want to drive the steps yourself, the package exposes the building blocks:
 
-* `stream.UngzipPayload(body []byte) ([]byte, error)` - returns body unchanged unless it begins with the gzip magic, in which case it is inflated.
+* `stream.GunzipPayload(body []byte) ([]byte, error)` - returns body unchanged unless it begins with the gzip magic, in which case it is inflated.
 * `stream.VerifySignature(body []byte, signature, secret string) bool` - constant-time HMAC-SHA256 check against the uncompressed bytes.
 * `stream.ParseEvent(payload []byte) (*stream.Event, error)` - JSON decode into a typed event.
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,7 @@ package stream_chat
 import (
 	"context"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -12,6 +13,9 @@ import (
 func init() {
 	rand.Seed(time.Now().UnixNano())
 
+	if os.Getenv("STREAM_KEY") == "" || os.Getenv("STREAM_SECRET") == "" {
+		return
+	}
 	if err := clearOldChannelTypes(); err != nil {
 		panic(err) // app has bad data from previous runs
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -13,10 +13,9 @@ import (
 	"io"
 )
 
-// ErrInvalidWebhookSignature is returned by VerifyAndParse* helpers when
-// the supplied signature does not match the HMAC computed over the
-// uncompressed JSON body.
-var ErrInvalidWebhookSignature = errors.New("invalid webhook signature")
+// ErrInvalidWebhook is the sentinel wrapped by every malformed-webhook /
+// verification error from this package so callers can use errors.Is with a single check.
+var ErrInvalidWebhook = errors.New("invalid webhook")
 
 var gzipMagic = []byte{0x1f, 0x8b}
 
@@ -32,15 +31,15 @@ func UngzipPayload(body []byte) ([]byte, error) {
 	}
 	zr, err := gzip.NewReader(bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("decompress gzip payload: %w", err)
+		return nil, fmt.Errorf("gzip decompression failed: %w", ErrInvalidWebhook)
 	}
 	out, err := io.ReadAll(zr)
 	if err != nil {
 		_ = zr.Close()
-		return nil, fmt.Errorf("read gzip payload: %w", err)
+		return nil, fmt.Errorf("gzip decompression failed: %w", ErrInvalidWebhook)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("finalize gzip payload: %w", err)
+		return nil, fmt.Errorf("gzip decompression failed: %w", ErrInvalidWebhook)
 	}
 	return out, nil
 }
@@ -52,7 +51,7 @@ func UngzipPayload(body []byte) ([]byte, error) {
 func DecodeSqsPayload(body string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(body)
 	if err != nil {
-		return nil, fmt.Errorf("base64-decode payload: %w", err)
+		return nil, fmt.Errorf("invalid base64 encoding: %w", ErrInvalidWebhook)
 	}
 	return UngzipPayload(decoded)
 }
@@ -90,16 +89,22 @@ func extractSnsMessage(notificationBody string) (string, bool) {
 	return *envelope.Message, true
 }
 
-// VerifySignature returns true when signature equals the hex-encoded
-// HMAC-SHA256 of body using secret as the key. The comparison is
-// constant-time. The signature is always computed over the
-// uncompressed JSON bytes, so callers that decoded a gzipped or
-// base64-wrapped payload must pass the inflated bytes here.
-func VerifySignature(body []byte, signature, secret string) bool {
+func signatureMatch(body []byte, signature, secret string) bool {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	expected := []byte(hex.EncodeToString(mac.Sum(nil)))
-	return hmac.Equal(expected, []byte(signature))
+	return len(signature) == len(expected) && hmac.Equal(expected, []byte(signature))
+}
+
+// VerifySignature compares the hex-encoded HMAC-SHA256 of body (using secret as the key)
+// to signature with a constant-time comparison. It returns nil on match.
+// On mismatch it returns an error wrapping ErrInvalidWebhook (message contains
+// "signature mismatch"). The digest is always over uncompressed JSON bytes.
+func VerifySignature(body []byte, signature, secret string) error {
+	if !signatureMatch(body, signature, secret) {
+		return fmt.Errorf("signature mismatch: %w", ErrInvalidWebhook)
+	}
+	return nil
 }
 
 // ParseEvent decodes the JSON-encoded webhook payload into a typed
@@ -108,22 +113,20 @@ func VerifySignature(body []byte, signature, secret string) bool {
 func ParseEvent(payload []byte) (*Event, error) {
 	var ev Event
 	if err := json.Unmarshal(payload, &ev); err != nil {
-		return nil, fmt.Errorf("parse webhook event: %w", err)
+		return nil, fmt.Errorf("invalid JSON payload: %w", ErrInvalidWebhook)
 	}
 	return &ev, nil
 }
 
 func verifyAndParse(payload []byte, signature, secret string) (*Event, error) {
-	if !VerifySignature(payload, signature, secret) {
-		return nil, ErrInvalidWebhookSignature
+	if err := VerifySignature(payload, signature, secret); err != nil {
+		return nil, err
 	}
 	return ParseEvent(payload)
 }
 
 // VerifyAndParseWebhook decompresses body when gzipped, verifies the
-// HMAC signature against secret, and returns the parsed Event. Returns
-// ErrInvalidWebhookSignature on mismatch and a wrapped error on any
-// decode failure.
+// HMAC signature against secret, and returns the parsed Event.
 func VerifyAndParseWebhook(body []byte, signature, secret string) (*Event, error) {
 	inflated, err := UngzipPayload(body)
 	if err != nil {

--- a/webhook.go
+++ b/webhook.go
@@ -20,13 +20,13 @@ var ErrInvalidWebhookSignature = errors.New("invalid webhook signature")
 
 var gzipMagic = []byte{0x1f, 0x8b}
 
-// UngzipPayload returns body unchanged unless the first two bytes are
+// GunzipPayload returns body unchanged unless the first two bytes are
 // the gzip magic (1f 8b, per RFC 1952), in which case the gzip stream
 // is inflated and the decompressed bytes are returned.
 //
 // Magic-byte detection lets the same handler stay correct when
 // middleware auto-decompresses the request before your code sees it.
-func UngzipPayload(body []byte) ([]byte, error) {
+func GunzipPayload(body []byte) ([]byte, error) {
 	if len(body) < 2 || !bytes.Equal(body[:2], gzipMagic) {
 		return body, nil
 	}
@@ -54,7 +54,7 @@ func DecodeSqsPayload(body string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("base64-decode payload: %w", err)
 	}
-	return UngzipPayload(decoded)
+	return GunzipPayload(decoded)
 }
 
 // DecodeSnsPayload reverses an SNS HTTP notification envelope: when the
@@ -125,7 +125,7 @@ func verifyAndParse(payload []byte, signature, secret string) (*Event, error) {
 // ErrInvalidWebhookSignature on mismatch and a wrapped error on any
 // decode failure.
 func VerifyAndParseWebhook(body []byte, signature, secret string) (*Event, error) {
-	inflated, err := UngzipPayload(body)
+	inflated, err := GunzipPayload(body)
 	if err != nil {
 		return nil, err
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -19,13 +19,13 @@ var ErrInvalidWebhook = errors.New("invalid webhook")
 
 var gzipMagic = []byte{0x1f, 0x8b}
 
-// UngzipPayload returns body unchanged unless the first two bytes are
+// GunzipPayload returns body unchanged unless the first two bytes are
 // the gzip magic (1f 8b, per RFC 1952), in which case the gzip stream
 // is inflated and the decompressed bytes are returned.
 //
 // Magic-byte detection lets the same handler stay correct when
 // middleware auto-decompresses the request before your code sees it.
-func UngzipPayload(body []byte) ([]byte, error) {
+func GunzipPayload(body []byte) ([]byte, error) {
 	if len(body) < 2 || !bytes.Equal(body[:2], gzipMagic) {
 		return body, nil
 	}
@@ -53,7 +53,7 @@ func DecodeSqsPayload(body string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid base64 encoding: %w", ErrInvalidWebhook)
 	}
-	return UngzipPayload(decoded)
+	return GunzipPayload(decoded)
 }
 
 // DecodeSnsPayload reverses an SNS HTTP notification envelope: when the
@@ -128,7 +128,7 @@ func verifyAndParse(payload []byte, signature, secret string) (*Event, error) {
 // VerifyAndParseWebhook decompresses body when gzipped, verifies the
 // HMAC signature against secret, and returns the parsed Event.
 func VerifyAndParseWebhook(body []byte, signature, secret string) (*Event, error) {
-	inflated, err := UngzipPayload(body)
+	inflated, err := GunzipPayload(body)
 	if err != nil {
 		return nil, err
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -13,10 +13,11 @@ import (
 	"io"
 )
 
-// ErrInvalidWebhookSignature is returned by VerifyAndParse* helpers when
-// the supplied signature does not match the HMAC computed over the
-// uncompressed JSON body.
-var ErrInvalidWebhookSignature = errors.New("invalid webhook signature")
+// ErrInvalidWebhook is the single sentinel that every webhook failure
+// path wraps. Callers can branch on it with errors.Is and, when they
+// need to distinguish the failure mode (signature mismatch, base64,
+// gzip, JSON), match a substring of the error message.
+var ErrInvalidWebhook = errors.New("invalid webhook")
 
 var gzipMagic = []byte{0x1f, 0x8b}
 
@@ -26,21 +27,24 @@ var gzipMagic = []byte{0x1f, 0x8b}
 //
 // Magic-byte detection lets the same handler stay correct when
 // middleware auto-decompresses the request before your code sees it.
+//
+// Any failure to inflate the gzip stream is wrapped in ErrInvalidWebhook
+// with the prefix "gzip decompression failed".
 func GunzipPayload(body []byte) ([]byte, error) {
 	if len(body) < 2 || !bytes.Equal(body[:2], gzipMagic) {
 		return body, nil
 	}
 	zr, err := gzip.NewReader(bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("decompress gzip payload: %w", err)
+		return nil, fmt.Errorf("gzip decompression failed: %v: %w", err, ErrInvalidWebhook)
 	}
 	out, err := io.ReadAll(zr)
 	if err != nil {
 		_ = zr.Close()
-		return nil, fmt.Errorf("read gzip payload: %w", err)
+		return nil, fmt.Errorf("gzip decompression failed: %v: %w", err, ErrInvalidWebhook)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("finalize gzip payload: %w", err)
+		return nil, fmt.Errorf("gzip decompression failed: %v: %w", err, ErrInvalidWebhook)
 	}
 	return out, nil
 }
@@ -49,10 +53,13 @@ func GunzipPayload(body []byte) ([]byte, error) {
 // is base64-decoded and, when the result begins with the gzip magic, it
 // is gzip-decompressed. The same call works whether or not Stream is
 // currently compressing payloads.
+//
+// A base64 failure is wrapped in ErrInvalidWebhook with the prefix
+// "invalid base64 encoding"; gzip failures propagate from GunzipPayload.
 func DecodeSqsPayload(body string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(body)
 	if err != nil {
-		return nil, fmt.Errorf("base64-decode payload: %w", err)
+		return nil, fmt.Errorf("invalid base64 encoding: %v: %w", err, ErrInvalidWebhook)
 	}
 	return GunzipPayload(decoded)
 }
@@ -63,6 +70,10 @@ func DecodeSqsPayload(body string) ([]byte, error) {
 // (base64-decode, then gzip-if-magic). When the input is not a JSON
 // envelope it is treated as the already-extracted Message string, so
 // existing call sites that pre-unwrap continue to work.
+//
+// Envelope parsing is lenient and never returns an error on its own;
+// any error returned here originates from the SQS pipeline and already
+// wraps ErrInvalidWebhook.
 func DecodeSnsPayload(notificationBody string) ([]byte, error) {
 	if msg, ok := extractSnsMessage(notificationBody); ok {
 		return DecodeSqsPayload(msg)
@@ -90,40 +101,45 @@ func extractSnsMessage(notificationBody string) (string, bool) {
 	return *envelope.Message, true
 }
 
-// VerifySignature returns true when signature equals the hex-encoded
-// HMAC-SHA256 of body using secret as the key. The comparison is
-// constant-time. The signature is always computed over the
-// uncompressed JSON bytes, so callers that decoded a gzipped or
+// VerifySignature returns nil when signature equals the hex-encoded
+// HMAC-SHA256 of body using secret as the key, and an error wrapping
+// ErrInvalidWebhook with the prefix "signature mismatch" otherwise. The
+// comparison is constant-time. The signature is always computed over
+// the uncompressed JSON bytes, so callers that decoded a gzipped or
 // base64-wrapped payload must pass the inflated bytes here.
-func VerifySignature(body []byte, signature, secret string) bool {
+func VerifySignature(body []byte, signature, secret string) error {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	expected := []byte(hex.EncodeToString(mac.Sum(nil)))
-	return hmac.Equal(expected, []byte(signature))
+	if !hmac.Equal(expected, []byte(signature)) {
+		return fmt.Errorf("signature mismatch: %w", ErrInvalidWebhook)
+	}
+	return nil
 }
 
 // ParseEvent decodes the JSON-encoded webhook payload into a typed
 // Event. Unknown event types still parse successfully because Event.Type
-// is a string alias.
+// is a string alias. JSON decode failures are wrapped in
+// ErrInvalidWebhook with the prefix "invalid JSON payload".
 func ParseEvent(payload []byte) (*Event, error) {
 	var ev Event
 	if err := json.Unmarshal(payload, &ev); err != nil {
-		return nil, fmt.Errorf("parse webhook event: %w", err)
+		return nil, fmt.Errorf("invalid JSON payload: %v: %w", err, ErrInvalidWebhook)
 	}
 	return &ev, nil
 }
 
 func verifyAndParse(payload []byte, signature, secret string) (*Event, error) {
-	if !VerifySignature(payload, signature, secret) {
-		return nil, ErrInvalidWebhookSignature
+	if err := VerifySignature(payload, signature, secret); err != nil {
+		return nil, err
 	}
 	return ParseEvent(payload)
 }
 
 // VerifyAndParseWebhook decompresses body when gzipped, verifies the
-// HMAC signature against secret, and returns the parsed Event. Returns
-// ErrInvalidWebhookSignature on mismatch and a wrapped error on any
-// decode failure.
+// HMAC signature against secret, and returns the parsed Event. Every
+// failure path wraps ErrInvalidWebhook, so callers can do
+// errors.Is(err, ErrInvalidWebhook) for a unified check.
 func VerifyAndParseWebhook(body []byte, signature, secret string) (*Event, error) {
 	inflated, err := GunzipPayload(body)
 	if err != nil {
@@ -134,6 +150,7 @@ func VerifyAndParseWebhook(body []byte, signature, secret string) (*Event, error
 
 // VerifyAndParseSqs decodes the SQS message Body, verifies the
 // X-Signature attribute against secret, and returns the parsed Event.
+// Every failure path wraps ErrInvalidWebhook.
 func VerifyAndParseSqs(messageBody, signature, secret string) (*Event, error) {
 	inflated, err := DecodeSqsPayload(messageBody)
 	if err != nil {
@@ -144,6 +161,7 @@ func VerifyAndParseSqs(messageBody, signature, secret string) (*Event, error) {
 
 // VerifyAndParseSns decodes the SNS notification Message, verifies the
 // X-Signature attribute against secret, and returns the parsed Event.
+// Every failure path wraps ErrInvalidWebhook.
 func VerifyAndParseSns(message, signature, secret string) (*Event, error) {
 	inflated, err := DecodeSnsPayload(message)
 	if err != nil {

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,106 @@
+package stream_chat
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ErrInvalidWebhookSignature is returned by VerifyAndDecodeWebhook when the
+// provided signature does not match the HMAC computed over the uncompressed
+// JSON body.
+var ErrInvalidWebhookSignature = errors.New("invalid webhook signature")
+
+// DecompressWebhookBody undoes the encoding wrappers Stream applies to
+// outbound webhook / SQS / SNS payloads, returning the raw JSON bytes
+// the server signed.
+//
+//   - payloadEncoding: optional transport wrapper applied last by the
+//     server. Currently the only supported value is "base64" (used for
+//     SQS / SNS firehose so the message stays valid UTF-8). Pass "" for
+//     HTTP webhooks.
+//   - contentEncoding: optional compression. Currently the only
+//     supported value is "gzip". Pass "" when no compression is set.
+//
+// Decode order is the inverse of how the server built the message:
+// base64 first, then gunzip. Both are case-insensitive and trimmed.
+func (c *Client) DecompressWebhookBody(body []byte, contentEncoding, payloadEncoding string) ([]byte, error) {
+	out := body
+
+	if pe := strings.ToLower(strings.TrimSpace(payloadEncoding)); pe != "" {
+		switch pe {
+		case "base64", "b64":
+			decoded, err := decodeBase64(out)
+			if err != nil {
+				return nil, fmt.Errorf("decode webhook payload_encoding=base64: %w", err)
+			}
+			out = decoded
+		default:
+			return nil, fmt.Errorf("unsupported webhook payload_encoding: %s. This SDK only supports base64.", payloadEncoding)
+		}
+	}
+
+	if ce := strings.ToLower(strings.TrimSpace(contentEncoding)); ce != "" {
+		switch ce {
+		case "gzip":
+			decompressed, err := gunzip(out)
+			if err != nil {
+				return nil, fmt.Errorf("decompress webhook Content-Encoding=gzip: %w", err)
+			}
+			out = decompressed
+		default:
+			return nil, fmt.Errorf(`unsupported webhook Content-Encoding: %s. This SDK only supports gzip; set webhook_compression_algorithm to "gzip" on the app config.`, contentEncoding)
+		}
+	}
+
+	return out, nil
+}
+
+// VerifyAndDecodeWebhook decompresses (when needed), verifies the HMAC
+// signature, and returns the uncompressed JSON bytes. The signature is
+// always computed over the innermost (uncompressed, base64-decoded)
+// JSON, so the verification rule is invariant across HTTP webhooks and
+// SQS / SNS.
+//
+//   - body: raw HTTP request body / SQS Body / SNS Message bytes
+//   - signature: value of the X-Signature header / message attribute
+//   - contentEncoding: value of Content-Encoding header / attribute
+//   - payloadEncoding: "base64" for SQS / SNS firehose, "" for HTTP webhooks
+//
+// Returns ErrInvalidWebhookSignature when the signature does not match.
+func (c *Client) VerifyAndDecodeWebhook(body []byte, signature, contentEncoding, payloadEncoding string) ([]byte, error) {
+	decoded, err := c.DecompressWebhookBody(body, contentEncoding, payloadEncoding)
+	if err != nil {
+		return nil, err
+	}
+
+	mac := hmac.New(sha256.New, c.apiSecret)
+	_, _ = mac.Write(decoded)
+	expected := []byte(hex.EncodeToString(mac.Sum(nil)))
+
+	if !hmac.Equal([]byte(signature), expected) {
+		return nil, ErrInvalidWebhookSignature
+	}
+
+	return decoded, nil
+}
+
+func decodeBase64(b []byte) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(string(b))
+}
+
+func gunzip(b []byte) ([]byte, error) {
+	zr, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	defer zr.Close()
+	return io.ReadAll(zr)
+}

--- a/webhook.go
+++ b/webhook.go
@@ -13,38 +13,34 @@ import (
 	"io"
 )
 
-// ErrInvalidWebhook is the single sentinel that every webhook failure
-// path wraps. Callers can branch on it with errors.Is and, when they
-// need to distinguish the failure mode (signature mismatch, base64,
-// gzip, JSON), match a substring of the error message.
-var ErrInvalidWebhook = errors.New("invalid webhook")
+// ErrInvalidWebhookSignature is returned by VerifyAndParse* helpers when
+// the supplied signature does not match the HMAC computed over the
+// uncompressed JSON body.
+var ErrInvalidWebhookSignature = errors.New("invalid webhook signature")
 
 var gzipMagic = []byte{0x1f, 0x8b}
 
-// GunzipPayload returns body unchanged unless the first two bytes are
+// UngzipPayload returns body unchanged unless the first two bytes are
 // the gzip magic (1f 8b, per RFC 1952), in which case the gzip stream
 // is inflated and the decompressed bytes are returned.
 //
 // Magic-byte detection lets the same handler stay correct when
 // middleware auto-decompresses the request before your code sees it.
-//
-// Any failure to inflate the gzip stream is wrapped in ErrInvalidWebhook
-// with the prefix "gzip decompression failed".
-func GunzipPayload(body []byte) ([]byte, error) {
+func UngzipPayload(body []byte) ([]byte, error) {
 	if len(body) < 2 || !bytes.Equal(body[:2], gzipMagic) {
 		return body, nil
 	}
 	zr, err := gzip.NewReader(bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("gzip decompression failed: %v: %w", err, ErrInvalidWebhook)
+		return nil, fmt.Errorf("decompress gzip payload: %w", err)
 	}
 	out, err := io.ReadAll(zr)
 	if err != nil {
 		_ = zr.Close()
-		return nil, fmt.Errorf("gzip decompression failed: %v: %w", err, ErrInvalidWebhook)
+		return nil, fmt.Errorf("read gzip payload: %w", err)
 	}
 	if err := zr.Close(); err != nil {
-		return nil, fmt.Errorf("gzip decompression failed: %v: %w", err, ErrInvalidWebhook)
+		return nil, fmt.Errorf("finalize gzip payload: %w", err)
 	}
 	return out, nil
 }
@@ -53,15 +49,12 @@ func GunzipPayload(body []byte) ([]byte, error) {
 // is base64-decoded and, when the result begins with the gzip magic, it
 // is gzip-decompressed. The same call works whether or not Stream is
 // currently compressing payloads.
-//
-// A base64 failure is wrapped in ErrInvalidWebhook with the prefix
-// "invalid base64 encoding"; gzip failures propagate from GunzipPayload.
 func DecodeSqsPayload(body string) ([]byte, error) {
 	decoded, err := base64.StdEncoding.DecodeString(body)
 	if err != nil {
-		return nil, fmt.Errorf("invalid base64 encoding: %v: %w", err, ErrInvalidWebhook)
+		return nil, fmt.Errorf("base64-decode payload: %w", err)
 	}
-	return GunzipPayload(decoded)
+	return UngzipPayload(decoded)
 }
 
 // DecodeSnsPayload reverses an SNS HTTP notification envelope: when the
@@ -70,10 +63,6 @@ func DecodeSqsPayload(body string) ([]byte, error) {
 // (base64-decode, then gzip-if-magic). When the input is not a JSON
 // envelope it is treated as the already-extracted Message string, so
 // existing call sites that pre-unwrap continue to work.
-//
-// Envelope parsing is lenient and never returns an error on its own;
-// any error returned here originates from the SQS pipeline and already
-// wraps ErrInvalidWebhook.
 func DecodeSnsPayload(notificationBody string) ([]byte, error) {
 	if msg, ok := extractSnsMessage(notificationBody); ok {
 		return DecodeSqsPayload(msg)
@@ -101,90 +90,66 @@ func extractSnsMessage(notificationBody string) (string, bool) {
 	return *envelope.Message, true
 }
 
-// VerifySignature returns nil when signature equals the hex-encoded
-// HMAC-SHA256 of body using secret as the key, and an error wrapping
-// ErrInvalidWebhook with the prefix "signature mismatch" otherwise. The
-// comparison is constant-time. The signature is always computed over
-// the uncompressed JSON bytes, so callers that decoded a gzipped or
+// VerifySignature returns true when signature equals the hex-encoded
+// HMAC-SHA256 of body using secret as the key. The comparison is
+// constant-time. The signature is always computed over the
+// uncompressed JSON bytes, so callers that decoded a gzipped or
 // base64-wrapped payload must pass the inflated bytes here.
-func VerifySignature(body []byte, signature, secret string) error {
+func VerifySignature(body []byte, signature, secret string) bool {
 	mac := hmac.New(sha256.New, []byte(secret))
 	_, _ = mac.Write(body)
 	expected := []byte(hex.EncodeToString(mac.Sum(nil)))
-	if !hmac.Equal(expected, []byte(signature)) {
-		return fmt.Errorf("signature mismatch: %w", ErrInvalidWebhook)
-	}
-	return nil
+	return hmac.Equal(expected, []byte(signature))
 }
 
 // ParseEvent decodes the JSON-encoded webhook payload into a typed
 // Event. Unknown event types still parse successfully because Event.Type
-// is a string alias. JSON decode failures are wrapped in
-// ErrInvalidWebhook with the prefix "invalid JSON payload".
+// is a string alias.
 func ParseEvent(payload []byte) (*Event, error) {
 	var ev Event
 	if err := json.Unmarshal(payload, &ev); err != nil {
-		return nil, fmt.Errorf("invalid JSON payload: %v: %w", err, ErrInvalidWebhook)
+		return nil, fmt.Errorf("parse webhook event: %w", err)
 	}
 	return &ev, nil
 }
 
 func verifyAndParse(payload []byte, signature, secret string) (*Event, error) {
-	if err := VerifySignature(payload, signature, secret); err != nil {
-		return nil, err
+	if !VerifySignature(payload, signature, secret) {
+		return nil, ErrInvalidWebhookSignature
 	}
 	return ParseEvent(payload)
 }
 
 // VerifyAndParseWebhook decompresses body when gzipped, verifies the
-// HMAC signature against secret, and returns the parsed Event. Every
-// failure path wraps ErrInvalidWebhook, so callers can do
-// errors.Is(err, ErrInvalidWebhook) for a unified check.
+// HMAC signature against secret, and returns the parsed Event. Returns
+// ErrInvalidWebhookSignature on mismatch and a wrapped error on any
+// decode failure.
 func VerifyAndParseWebhook(body []byte, signature, secret string) (*Event, error) {
-	inflated, err := GunzipPayload(body)
+	inflated, err := UngzipPayload(body)
 	if err != nil {
 		return nil, err
 	}
 	return verifyAndParse(inflated, signature, secret)
 }
 
-// VerifyAndParseSqs decodes the SQS message Body and returns the parsed
-// Event. Signature verification is opt-in: pass both signature and
-// secret as non-empty strings to run the full HMAC check, or pass both
-// as empty strings to skip verification (the default for AWS-transport
-// deliveries, where the queue itself is the authentication layer).
-// Passing exactly one of the two is treated as a programmer error.
-// Every failure path wraps ErrInvalidWebhook.
-func VerifyAndParseSqs(messageBody, signature, secret string) (*Event, error) {
+// ParseSqs decodes the SQS message Body and returns the parsed Event.
+// Stream does not attach an HMAC to SQS deliveries; use VerifyAndParseWebhook for HTTP.
+func ParseSqs(messageBody string) (*Event, error) {
 	inflated, err := DecodeSqsPayload(messageBody)
 	if err != nil {
 		return nil, err
 	}
-	if signature == "" && secret == "" {
-		return ParseEvent(inflated)
-	}
-	if signature == "" || secret == "" {
-		return nil, fmt.Errorf("signature and secret must both be provided to verify the SQS/SNS payload: %w", ErrInvalidWebhook)
-	}
-	return verifyAndParse(inflated, signature, secret)
+	return ParseEvent(inflated)
 }
 
-// VerifyAndParseSns decodes the SNS notification Message and returns
-// the parsed Event. Signature verification follows the same opt-in
-// rules as VerifyAndParseSqs: both empty skips, both set runs the HMAC
-// check, exactly one set returns an error wrapping ErrInvalidWebhook.
-func VerifyAndParseSns(message, signature, secret string) (*Event, error) {
+// ParseSns decodes an SNS-delivered payload (unwraps SNS envelope when
+// present), then parses the inner JSON Event. No HMAC verification.
+func ParseSns(message string) (*Event, error) {
 	inflated, err := DecodeSnsPayload(message)
 	if err != nil {
 		return nil, err
 	}
-	if signature == "" && secret == "" {
-		return ParseEvent(inflated)
-	}
-	if signature == "" || secret == "" {
-		return nil, fmt.Errorf("signature and secret must both be provided to verify the SQS/SNS payload: %w", ErrInvalidWebhook)
-	}
-	return verifyAndParse(inflated, signature, secret)
+	return ParseEvent(inflated)
 }
 
 // VerifyAndParseWebhook is the client-bound form of the package-level

--- a/webhook.go
+++ b/webhook.go
@@ -7,100 +7,134 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 )
 
-// ErrInvalidWebhookSignature is returned by VerifyAndDecodeWebhook when the
-// provided signature does not match the HMAC computed over the uncompressed
-// JSON body.
+// ErrInvalidWebhookSignature is returned by VerifyAndParse* helpers when
+// the supplied signature does not match the HMAC computed over the
+// uncompressed JSON body.
 var ErrInvalidWebhookSignature = errors.New("invalid webhook signature")
 
-// DecompressWebhookBody undoes the encoding wrappers Stream applies to
-// outbound webhook / SQS / SNS payloads, returning the raw JSON bytes
-// the server signed.
+var gzipMagic = []byte{0x1f, 0x8b, 0x08}
+
+// UngzipPayload returns body unchanged unless the first three bytes are
+// the gzip magic (1f 8b 08), in which case the gzip stream is inflated
+// and the decompressed bytes are returned.
 //
-//   - payloadEncoding: optional transport wrapper applied last by the
-//     server. Currently the only supported value is "base64" (used for
-//     SQS / SNS firehose so the message stays valid UTF-8). Pass "" for
-//     HTTP webhooks.
-//   - contentEncoding: optional compression. Currently the only
-//     supported value is "gzip". Pass "" when no compression is set.
-//
-// Decode order is the inverse of how the server built the message:
-// base64 first, then gunzip. Both are case-insensitive and trimmed.
-func (c *Client) DecompressWebhookBody(body []byte, contentEncoding, payloadEncoding string) ([]byte, error) {
-	out := body
-
-	if pe := strings.ToLower(strings.TrimSpace(payloadEncoding)); pe != "" {
-		switch pe {
-		case "base64", "b64":
-			decoded, err := decodeBase64(out)
-			if err != nil {
-				return nil, fmt.Errorf("decode webhook payload_encoding=base64: %w", err)
-			}
-			out = decoded
-		default:
-			return nil, fmt.Errorf("unsupported webhook payload_encoding: %s. This SDK only supports base64.", payloadEncoding)
-		}
+// Magic-byte detection lets the same handler stay correct when
+// middleware auto-decompresses the request before your code sees it.
+func UngzipPayload(body []byte) ([]byte, error) {
+	if len(body) < 3 || !bytes.Equal(body[:3], gzipMagic) {
+		return body, nil
 	}
-
-	if ce := strings.ToLower(strings.TrimSpace(contentEncoding)); ce != "" {
-		switch ce {
-		case "gzip":
-			decompressed, err := gunzip(out)
-			if err != nil {
-				return nil, fmt.Errorf("decompress webhook Content-Encoding=gzip: %w", err)
-			}
-			out = decompressed
-		default:
-			return nil, fmt.Errorf(`unsupported webhook Content-Encoding: %s. This SDK only supports gzip; set webhook_compression_algorithm to "gzip" on the app config.`, contentEncoding)
-		}
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("decompress gzip payload: %w", err)
 	}
-
+	defer zr.Close()
+	out, err := io.ReadAll(zr)
+	if err != nil {
+		return nil, fmt.Errorf("read gzip payload: %w", err)
+	}
 	return out, nil
 }
 
-// VerifyAndDecodeWebhook decompresses (when needed), verifies the HMAC
-// signature, and returns the uncompressed JSON bytes. The signature is
-// always computed over the innermost (uncompressed, base64-decoded)
-// JSON, so the verification rule is invariant across HTTP webhooks and
-// SQS / SNS.
-//
-//   - body: raw HTTP request body / SQS Body / SNS Message bytes
-//   - signature: value of the X-Signature header / message attribute
-//   - contentEncoding: value of Content-Encoding header / attribute
-//   - payloadEncoding: "base64" for SQS / SNS firehose, "" for HTTP webhooks
-//
-// Returns ErrInvalidWebhookSignature when the signature does not match.
-func (c *Client) VerifyAndDecodeWebhook(body []byte, signature, contentEncoding, payloadEncoding string) ([]byte, error) {
-	decoded, err := c.DecompressWebhookBody(body, contentEncoding, payloadEncoding)
+// DecodeSqsPayload reverses the SQS firehose envelope: the message Body
+// is base64-decoded and, when the result begins with the gzip magic, it
+// is gzip-decompressed. The same call works whether or not Stream is
+// currently compressing payloads.
+func DecodeSqsPayload(body string) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("base64-decode payload: %w", err)
 	}
+	return UngzipPayload(decoded)
+}
 
-	mac := hmac.New(sha256.New, c.apiSecret)
-	_, _ = mac.Write(decoded)
+// DecodeSnsPayload is byte-for-byte identical to DecodeSqsPayload;
+// exposed under both names so call sites read intent.
+func DecodeSnsPayload(message string) ([]byte, error) {
+	return DecodeSqsPayload(message)
+}
+
+// VerifySignature returns true when signature equals the hex-encoded
+// HMAC-SHA256 of body using secret as the key. The comparison is
+// constant-time. The signature is always computed over the
+// uncompressed JSON bytes, so callers that decoded a gzipped or
+// base64-wrapped payload must pass the inflated bytes here.
+func VerifySignature(body []byte, signature, secret string) bool {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
 	expected := []byte(hex.EncodeToString(mac.Sum(nil)))
+	return hmac.Equal(expected, []byte(signature))
+}
 
-	if !hmac.Equal([]byte(signature), expected) {
+// ParseEvent decodes the JSON-encoded webhook payload into a typed
+// Event. Unknown event types still parse successfully because Event.Type
+// is a string alias.
+func ParseEvent(payload []byte) (*Event, error) {
+	var ev Event
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return nil, fmt.Errorf("parse webhook event: %w", err)
+	}
+	return &ev, nil
+}
+
+func verifyAndParse(payload []byte, signature, secret string) (*Event, error) {
+	if !VerifySignature(payload, signature, secret) {
 		return nil, ErrInvalidWebhookSignature
 	}
-
-	return decoded, nil
+	return ParseEvent(payload)
 }
 
-func decodeBase64(b []byte) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(string(b))
-}
-
-func gunzip(b []byte) ([]byte, error) {
-	zr, err := gzip.NewReader(bytes.NewReader(b))
+// VerifyAndParseWebhook decompresses body when gzipped, verifies the
+// HMAC signature against secret, and returns the parsed Event. Returns
+// ErrInvalidWebhookSignature on mismatch and a wrapped error on any
+// decode failure.
+func VerifyAndParseWebhook(body []byte, signature, secret string) (*Event, error) {
+	inflated, err := UngzipPayload(body)
 	if err != nil {
 		return nil, err
 	}
-	defer zr.Close()
-	return io.ReadAll(zr)
+	return verifyAndParse(inflated, signature, secret)
+}
+
+// VerifyAndParseSqs decodes the SQS message Body, verifies the
+// X-Signature attribute against secret, and returns the parsed Event.
+func VerifyAndParseSqs(messageBody, signature, secret string) (*Event, error) {
+	inflated, err := DecodeSqsPayload(messageBody)
+	if err != nil {
+		return nil, err
+	}
+	return verifyAndParse(inflated, signature, secret)
+}
+
+// VerifyAndParseSns decodes the SNS notification Message, verifies the
+// X-Signature attribute against secret, and returns the parsed Event.
+func VerifyAndParseSns(message, signature, secret string) (*Event, error) {
+	inflated, err := DecodeSnsPayload(message)
+	if err != nil {
+		return nil, err
+	}
+	return verifyAndParse(inflated, signature, secret)
+}
+
+// VerifyAndParseWebhook is the client-bound form of the package-level
+// helper; it pulls the API secret from the receiver so call sites only
+// supply the request body and signature.
+func (c *Client) VerifyAndParseWebhook(body []byte, signature string) (*Event, error) {
+	return VerifyAndParseWebhook(body, signature, string(c.apiSecret))
+}
+
+// VerifyAndParseSqs is the client-bound form of the package-level helper.
+func (c *Client) VerifyAndParseSqs(messageBody, signature string) (*Event, error) {
+	return VerifyAndParseSqs(messageBody, signature, string(c.apiSecret))
+}
+
+// VerifyAndParseSns is the client-bound form of the package-level helper.
+func (c *Client) VerifyAndParseSns(message, signature string) (*Event, error) {
+	return VerifyAndParseSns(message, signature, string(c.apiSecret))
 }

--- a/webhook.go
+++ b/webhook.go
@@ -57,10 +57,37 @@ func DecodeSqsPayload(body string) ([]byte, error) {
 	return UngzipPayload(decoded)
 }
 
-// DecodeSnsPayload is byte-for-byte identical to DecodeSqsPayload;
-// exposed under both names so call sites read intent.
-func DecodeSnsPayload(message string) ([]byte, error) {
-	return DecodeSqsPayload(message)
+// DecodeSnsPayload reverses an SNS HTTP notification envelope: when the
+// input is a JSON envelope ({"Type":"Notification","Message":"..."}),
+// the inner Message field is extracted and run through the SQS pipeline
+// (base64-decode, then gzip-if-magic). When the input is not a JSON
+// envelope it is treated as the already-extracted Message string, so
+// existing call sites that pre-unwrap continue to work.
+func DecodeSnsPayload(notificationBody string) ([]byte, error) {
+	if msg, ok := extractSnsMessage(notificationBody); ok {
+		return DecodeSqsPayload(msg)
+	}
+	return DecodeSqsPayload(notificationBody)
+}
+
+// extractSnsMessage returns the inner Message field from an SNS HTTP
+// notification envelope. The ok result is false when input is not a JSON
+// object with a string Message field.
+func extractSnsMessage(notificationBody string) (string, bool) {
+	trimmed := bytes.TrimLeft([]byte(notificationBody), " \t\r\n")
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return "", false
+	}
+	var envelope struct {
+		Message *string `json:"Message"`
+	}
+	if err := json.Unmarshal(trimmed, &envelope); err != nil {
+		return "", false
+	}
+	if envelope.Message == nil {
+		return "", false
+	}
+	return *envelope.Message, true
 }
 
 // VerifySignature returns true when signature equals the hex-encoded

--- a/webhook.go
+++ b/webhook.go
@@ -34,10 +34,13 @@ func UngzipPayload(body []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("decompress gzip payload: %w", err)
 	}
-	defer zr.Close()
 	out, err := io.ReadAll(zr)
 	if err != nil {
+		_ = zr.Close()
 		return nil, fmt.Errorf("read gzip payload: %w", err)
+	}
+	if err := zr.Close(); err != nil {
+		return nil, fmt.Errorf("finalize gzip payload: %w", err)
 	}
 	return out, nil
 }

--- a/webhook.go
+++ b/webhook.go
@@ -18,16 +18,16 @@ import (
 // uncompressed JSON body.
 var ErrInvalidWebhookSignature = errors.New("invalid webhook signature")
 
-var gzipMagic = []byte{0x1f, 0x8b, 0x08}
+var gzipMagic = []byte{0x1f, 0x8b}
 
-// UngzipPayload returns body unchanged unless the first three bytes are
-// the gzip magic (1f 8b 08), in which case the gzip stream is inflated
-// and the decompressed bytes are returned.
+// UngzipPayload returns body unchanged unless the first two bytes are
+// the gzip magic (1f 8b, per RFC 1952), in which case the gzip stream
+// is inflated and the decompressed bytes are returned.
 //
 // Magic-byte detection lets the same handler stay correct when
 // middleware auto-decompresses the request before your code sees it.
 func UngzipPayload(body []byte) ([]byte, error) {
-	if len(body) < 3 || !bytes.Equal(body[:3], gzipMagic) {
+	if len(body) < 2 || !bytes.Equal(body[:2], gzipMagic) {
 		return body, nil
 	}
 	zr, err := gzip.NewReader(bytes.NewReader(body))

--- a/webhook.go
+++ b/webhook.go
@@ -148,24 +148,41 @@ func VerifyAndParseWebhook(body []byte, signature, secret string) (*Event, error
 	return verifyAndParse(inflated, signature, secret)
 }
 
-// VerifyAndParseSqs decodes the SQS message Body, verifies the
-// X-Signature attribute against secret, and returns the parsed Event.
+// VerifyAndParseSqs decodes the SQS message Body and returns the parsed
+// Event. Signature verification is opt-in: pass both signature and
+// secret as non-empty strings to run the full HMAC check, or pass both
+// as empty strings to skip verification (the default for AWS-transport
+// deliveries, where the queue itself is the authentication layer).
+// Passing exactly one of the two is treated as a programmer error.
 // Every failure path wraps ErrInvalidWebhook.
 func VerifyAndParseSqs(messageBody, signature, secret string) (*Event, error) {
 	inflated, err := DecodeSqsPayload(messageBody)
 	if err != nil {
 		return nil, err
 	}
+	if signature == "" && secret == "" {
+		return ParseEvent(inflated)
+	}
+	if signature == "" || secret == "" {
+		return nil, fmt.Errorf("signature and secret must both be provided to verify the SQS/SNS payload: %w", ErrInvalidWebhook)
+	}
 	return verifyAndParse(inflated, signature, secret)
 }
 
-// VerifyAndParseSns decodes the SNS notification Message, verifies the
-// X-Signature attribute against secret, and returns the parsed Event.
-// Every failure path wraps ErrInvalidWebhook.
+// VerifyAndParseSns decodes the SNS notification Message and returns
+// the parsed Event. Signature verification follows the same opt-in
+// rules as VerifyAndParseSqs: both empty skips, both set runs the HMAC
+// check, exactly one set returns an error wrapping ErrInvalidWebhook.
 func VerifyAndParseSns(message, signature, secret string) (*Event, error) {
 	inflated, err := DecodeSnsPayload(message)
 	if err != nil {
 		return nil, err
+	}
+	if signature == "" && secret == "" {
+		return ParseEvent(inflated)
+	}
+	if signature == "" || secret == "" {
+		return nil, fmt.Errorf("signature and secret must both be provided to verify the SQS/SNS payload: %w", ErrInvalidWebhook)
 	}
 	return verifyAndParse(inflated, signature, secret)
 }
@@ -175,14 +192,4 @@ func VerifyAndParseSns(message, signature, secret string) (*Event, error) {
 // supply the request body and signature.
 func (c *Client) VerifyAndParseWebhook(body []byte, signature string) (*Event, error) {
 	return VerifyAndParseWebhook(body, signature, string(c.apiSecret))
-}
-
-// VerifyAndParseSqs is the client-bound form of the package-level helper.
-func (c *Client) VerifyAndParseSqs(messageBody, signature string) (*Event, error) {
-	return VerifyAndParseSqs(messageBody, signature, string(c.apiSecret))
-}
-
-// VerifyAndParseSns is the client-bound form of the package-level helper.
-func (c *Client) VerifyAndParseSns(message, signature string) (*Event, error) {
-	return VerifyAndParseSns(message, signature, string(c.apiSecret))
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -383,3 +383,127 @@ func TestVerifyAndParseSns(t *testing.T) {
 		require.Nil(t, got)
 	})
 }
+
+func TestVerifyAndParseSqs_NoSignature(t *testing.T) {
+	body := []byte(webhookTestFixture)
+
+	t.Run("plain base64 body", func(t *testing.T) {
+		got, err := VerifyAndParseSqs(base64String(t, body), "", "")
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+		require.NotNil(t, got.Message)
+		require.Equal(t, "the quick brown fox", got.Message.Text)
+	})
+
+	t.Run("base64 plus gzip body", func(t *testing.T) {
+		got, err := VerifyAndParseSqs(base64String(t, gzipBytes(t, body)), "", "")
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("invalid base64 still surfaces as ErrInvalidWebhook", func(t *testing.T) {
+		got, err := VerifyAndParseSqs("!!!not-base64!!!", "", "")
+		require.Error(t, err)
+		require.Nil(t, got)
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "invalid base64 encoding")
+	})
+}
+
+func TestVerifyAndParseSns_NoSignature(t *testing.T) {
+	body := []byte(webhookTestFixture)
+	wrapped := base64String(t, gzipBytes(t, body))
+
+	t.Run("pre-extracted Message", func(t *testing.T) {
+		got, err := VerifyAndParseSns(wrapped, "", "")
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("full SNS HTTP notification envelope", func(t *testing.T) {
+		envelope := snsEnvelope(t, wrapped)
+		got, err := VerifyAndParseSns(envelope, "", "")
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+		require.NotNil(t, got.Message)
+		require.Equal(t, "the quick brown fox", got.Message.Text)
+	})
+}
+
+func TestClient_VerifyAndParseSqs_NoSignature(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+	wrapped := base64String(t, gzipBytes(t, body))
+
+	t.Run("zero signature args skips verification", func(t *testing.T) {
+		got, err := c.VerifyAndParseSqs(wrapped)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("one signature arg verifies against client secret", func(t *testing.T) {
+		sig := hmacHex(t, []byte(webhookTestAPISecret), body)
+		got, err := c.VerifyAndParseSqs(wrapped, sig)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("more than one signature arg is rejected", func(t *testing.T) {
+		got, err := c.VerifyAndParseSqs(wrapped, "sig-a", "sig-b")
+		require.Error(t, err)
+		require.Nil(t, got)
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "accepts at most one signature argument")
+	})
+
+	t.Run("variadic form on Sns mirrors Sqs", func(t *testing.T) {
+		envelope := snsEnvelope(t, wrapped)
+		got, err := c.VerifyAndParseSns(envelope)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+
+		got, err = c.VerifyAndParseSns(envelope, "sig-a", "sig-b")
+		require.Error(t, err)
+		require.Nil(t, got)
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "accepts at most one signature argument")
+	})
+}
+
+func TestVerifyAndParseSqs_RejectsPartialCreds(t *testing.T) {
+	body := []byte(webhookTestFixture)
+	wrapped := base64String(t, gzipBytes(t, body))
+	envelope := snsEnvelope(t, wrapped)
+
+	cases := []struct {
+		name string
+		call func() (*Event, error)
+	}{
+		{
+			name: "sqs signature only",
+			call: func() (*Event, error) { return VerifyAndParseSqs(wrapped, "sig", "") },
+		},
+		{
+			name: "sqs secret only",
+			call: func() (*Event, error) { return VerifyAndParseSqs(wrapped, "", "sec") },
+		},
+		{
+			name: "sns signature only",
+			call: func() (*Event, error) { return VerifyAndParseSns(envelope, "sig", "") },
+		},
+		{
+			name: "sns secret only",
+			call: func() (*Event, error) { return VerifyAndParseSns(envelope, "", "sec") },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.call()
+			require.Error(t, err)
+			require.Nil(t, got)
+			require.True(t, errors.Is(err, ErrInvalidWebhook))
+			assert.Contains(t, err.Error(), "signature and secret must both be provided")
+		})
+	}
+}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -124,12 +125,51 @@ func TestDecodeSnsPayload(t *testing.T) {
 	body := []byte(webhookTestFixture)
 	wrapped := base64String(t, gzipBytes(t, body))
 
-	sns, err := DecodeSnsPayload(wrapped)
+	t.Run("pre-extracted message backward compat", func(t *testing.T) {
+		sns, err := DecodeSnsPayload(wrapped)
+		require.NoError(t, err)
+		sqs, err := DecodeSqsPayload(wrapped)
+		require.NoError(t, err)
+		require.Equal(t, sqs, sns)
+		require.Equal(t, body, sns)
+	})
+
+	t.Run("full SNS HTTP notification envelope", func(t *testing.T) {
+		envelope := snsEnvelope(t, wrapped)
+		got, err := DecodeSnsPayload(envelope)
+		require.NoError(t, err)
+		require.Equal(t, body, got)
+	})
+
+	t.Run("envelope with whitespace prefix", func(t *testing.T) {
+		envelope := "  \n" + snsEnvelope(t, wrapped)
+		got, err := DecodeSnsPayload(envelope)
+		require.NoError(t, err)
+		require.Equal(t, body, got)
+	})
+}
+
+// snsEnvelope returns a realistic SNS HTTP POST notification body that
+// wraps payload as the Message field. Matches the documented SNS schema.
+func snsEnvelope(t *testing.T, payload string) string {
+	t.Helper()
+	env := map[string]any{
+		"Type":             "Notification",
+		"MessageId":        "22b80b92-fdea-4c2c-8f9d-bdfb0c7bf324",
+		"TopicArn":         "arn:aws:sns:us-east-1:123456789012:stream-webhooks",
+		"Message":          payload,
+		"Timestamp":        "2026-05-11T10:00:00.000Z",
+		"SignatureVersion": "1",
+		"MessageAttributes": map[string]any{
+			"X-Signature": map[string]string{
+				"Type":  "String",
+				"Value": "<signature placeholder>",
+			},
+		},
+	}
+	out, err := json.Marshal(env)
 	require.NoError(t, err)
-	sqs, err := DecodeSqsPayload(wrapped)
-	require.NoError(t, err)
-	require.Equal(t, sqs, sns)
-	require.Equal(t, body, sns)
+	return string(out)
 }
 
 func TestVerifySignature(t *testing.T) {
@@ -270,11 +310,29 @@ func TestVerifyAndParseSns(t *testing.T) {
 	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
 	wrapped := base64String(t, gzipBytes(t, body))
 
-	got, err := c.VerifyAndParseSns(wrapped, sig)
-	require.NoError(t, err)
-	require.Equal(t, EventMessageNew, got.Type)
+	t.Run("pre-extracted message backward compat", func(t *testing.T) {
+		got, err := c.VerifyAndParseSns(wrapped, sig)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
 
-	pkg, err := VerifyAndParseSns(wrapped, sig, webhookTestAPISecret)
-	require.NoError(t, err)
-	require.Equal(t, got.Type, pkg.Type)
+		pkg, err := VerifyAndParseSns(wrapped, sig, webhookTestAPISecret)
+		require.NoError(t, err)
+		require.Equal(t, got.Type, pkg.Type)
+	})
+
+	t.Run("full SNS HTTP notification envelope", func(t *testing.T) {
+		envelope := snsEnvelope(t, wrapped)
+		got, err := c.VerifyAndParseSns(envelope, sig)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("envelope signature verifies against inner payload", func(t *testing.T) {
+		envelope := snsEnvelope(t, wrapped)
+		envelopeSig := hmacHex(t, []byte(webhookTestAPISecret), []byte(envelope))
+		got, err := c.VerifyAndParseSns(envelope, envelopeSig)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.Nil(t, got)
+	})
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -89,12 +89,13 @@ func TestGunzipPayload(t *testing.T) {
 		require.Equal(t, []byte("ab"), got)
 	})
 
-	t.Run("truncated gzip with magic returns error", func(t *testing.T) {
+	t.Run("gunzipPayload returns ErrInvalidWebhook on corrupt gzip", func(t *testing.T) {
 		bad := append(append([]byte{}, gzipMagic...), 0, 0, 0)
 		got, err := GunzipPayload(bad)
 		require.Error(t, err)
 		require.Nil(t, got)
-		assert.Contains(t, err.Error(), "gzip")
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "gzip decompression failed")
 	})
 
 	t.Run("decompresses helloworld fixture", func(t *testing.T) {
@@ -121,11 +122,12 @@ func TestDecodeSqsPayload(t *testing.T) {
 		require.Equal(t, body, got)
 	})
 
-	t.Run("invalid base64 raises", func(t *testing.T) {
+	t.Run("decodeSqsPayload returns ErrInvalidWebhook on invalid base64", func(t *testing.T) {
 		got, err := DecodeSqsPayload("!!!not-base64!!!")
 		require.Error(t, err)
 		require.Nil(t, got)
-		assert.Contains(t, err.Error(), "base64")
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "invalid base64 encoding")
 	})
 
 	t.Run("helloworld base64 fixture", func(t *testing.T) {
@@ -196,14 +198,31 @@ func TestVerifySignature(t *testing.T) {
 	body := []byte(webhookTestFixture)
 	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
 
-	require.True(t, VerifySignature(body, sig, webhookTestAPISecret))
-	require.False(t, VerifySignature(body, "0000000000000000000000000000000000000000000000000000000000000000", webhookTestAPISecret))
-	require.False(t, VerifySignature(body, sig, "different-secret"))
+	t.Run("valid signature returns nil", func(t *testing.T) {
+		require.NoError(t, VerifySignature(body, sig, webhookTestAPISecret))
+	})
 
-	compressed := gzipBytes(t, body)
-	sigOverCompressed := hmacHex(t, []byte(webhookTestAPISecret), compressed)
-	require.False(t, VerifySignature(body, sigOverCompressed, webhookTestAPISecret),
-		"signature must be computed over uncompressed bytes")
+	t.Run("verifySignature returns ErrInvalidWebhook on mismatch", func(t *testing.T) {
+		err := VerifySignature(body, "0000000000000000000000000000000000000000000000000000000000000000", webhookTestAPISecret)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "signature mismatch")
+	})
+
+	t.Run("wrong secret rejected", func(t *testing.T) {
+		err := VerifySignature(body, sig, "different-secret")
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "signature mismatch")
+	})
+
+	t.Run("signature over compressed bytes rejected", func(t *testing.T) {
+		compressed := gzipBytes(t, body)
+		sigOverCompressed := hmacHex(t, []byte(webhookTestAPISecret), compressed)
+		err := VerifySignature(body, sigOverCompressed, webhookTestAPISecret)
+		require.Error(t, err, "signature must be computed over uncompressed bytes")
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+	})
 }
 
 func TestParseEvent(t *testing.T) {
@@ -221,10 +240,12 @@ func TestParseEvent(t *testing.T) {
 		require.Equal(t, EventType("a.future.event"), got.Type)
 	})
 
-	t.Run("malformed json returns error", func(t *testing.T) {
+	t.Run("parseEvent returns ErrInvalidWebhook on invalid JSON", func(t *testing.T) {
 		got, err := ParseEvent([]byte("not json"))
 		require.Error(t, err)
 		require.Nil(t, got)
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "invalid JSON payload")
 	})
 }
 
@@ -257,10 +278,11 @@ func TestVerifyAndParseWebhook(t *testing.T) {
 		require.Equal(t, EventMessageNew, got.Type)
 	})
 
-	t.Run("signature mismatch returns ErrInvalidWebhookSignature", func(t *testing.T) {
+	t.Run("signature mismatch returns ErrInvalidWebhook", func(t *testing.T) {
 		got, err := c.VerifyAndParseWebhook(body, strings.Repeat("0", 64))
 		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "signature mismatch")
 		require.Nil(t, got)
 	})
 
@@ -269,15 +291,17 @@ func TestVerifyAndParseWebhook(t *testing.T) {
 		sigOverCompressed := hmacHex(t, []byte(webhookTestAPISecret), compressed)
 		got, err := c.VerifyAndParseWebhook(compressed, sigOverCompressed)
 		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "signature mismatch")
 		require.Nil(t, got)
 	})
 
-	t.Run("propagates decompression error", func(t *testing.T) {
+	t.Run("propagates decompression error as ErrInvalidWebhook", func(t *testing.T) {
 		bogus := append(append([]byte{}, gzipMagic...), []byte("garbage")...)
 		got, err := c.VerifyAndParseWebhook(bogus, sig)
 		require.Error(t, err)
-		require.False(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "gzip decompression failed")
 		require.Nil(t, got)
 	})
 }
@@ -312,14 +336,16 @@ func TestVerifyAndParseSqs(t *testing.T) {
 		sigOverWrapped := hmacHex(t, []byte(webhookTestAPISecret), []byte(wrapped))
 		got, err := c.VerifyAndParseSqs(wrapped, sigOverWrapped)
 		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "signature mismatch")
 		require.Nil(t, got)
 	})
 
-	t.Run("invalid base64 surfaced as error", func(t *testing.T) {
+	t.Run("invalid base64 surfaced as ErrInvalidWebhook", func(t *testing.T) {
 		got, err := c.VerifyAndParseSqs("!!!not-base64!!!", sig)
 		require.Error(t, err)
-		require.False(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "invalid base64 encoding")
 		require.Nil(t, got)
 	})
 }
@@ -352,7 +378,8 @@ func TestVerifyAndParseSns(t *testing.T) {
 		envelopeSig := hmacHex(t, []byte(webhookTestAPISecret), []byte(envelope))
 		got, err := c.VerifyAndParseSns(envelope, envelopeSig)
 		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.True(t, errors.Is(err, ErrInvalidWebhook))
+		assert.Contains(t, err.Error(), "signature mismatch")
 		require.Nil(t, got)
 	})
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,0 +1,275 @@
+package stream_chat
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	webhookTestAPIKey    = "tkey1"
+	webhookTestAPISecret = "tsec2"
+	webhookTestFixture   = `{"type":"message.new","message":{"text":"the quick brown fox"}}`
+)
+
+func newWebhookTestClient(t *testing.T) *Client {
+	t.Helper()
+	c, err := NewClient(webhookTestAPIKey, webhookTestAPISecret)
+	require.NoError(t, err, "new client")
+	return c
+}
+
+func hmacHex(t *testing.T, secret, body []byte) []byte {
+	t.Helper()
+	mac := hmac.New(sha256.New, secret)
+	_, err := mac.Write(body)
+	require.NoError(t, err)
+	return []byte(hex.EncodeToString(mac.Sum(nil)))
+}
+
+func gzipBytes(t *testing.T, src []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(src)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func base64Bytes(t *testing.T, src []byte) []byte {
+	t.Helper()
+	return []byte(base64.StdEncoding.EncodeToString(src))
+}
+
+func TestVerifyWebhook_BackwardCompatibility(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
+
+	require.True(t, c.VerifyWebhook(body, sig), "valid signature must verify")
+	require.False(t, c.VerifyWebhook(body, []byte("not-a-valid-hex-signature")), "invalid signature must not verify")
+	require.False(t, c.VerifyWebhook([]byte("tampered"), sig), "tampered body must not verify")
+}
+
+func TestDecompressWebhookBody(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+
+	gzipped := gzipBytes(t, body)
+	b64Plain := base64Bytes(t, body)
+	b64Gzipped := base64Bytes(t, gzipped)
+
+	tests := []struct {
+		name            string
+		body            []byte
+		contentEncoding string
+		payloadEncoding string
+		want            []byte
+	}{
+		{
+			name: "passthrough when both encodings empty",
+			body: body,
+			want: body,
+		},
+		{
+			name:            "passthrough when both encodings whitespace",
+			body:            body,
+			contentEncoding: "  ",
+			payloadEncoding: "\t",
+			want:            body,
+		},
+		{
+			name:            "gzip round-trip",
+			body:            gzipped,
+			contentEncoding: "gzip",
+			want:            body,
+		},
+		{
+			name:            "base64 round-trip without compression",
+			body:            b64Plain,
+			payloadEncoding: "base64",
+			want:            body,
+		},
+		{
+			name:            "base64 + gzip round-trip (SQS / SNS shape)",
+			body:            b64Gzipped,
+			contentEncoding: "gzip",
+			payloadEncoding: "base64",
+			want:            body,
+		},
+		{
+			name:            "case-insensitive GZIP",
+			body:            gzipped,
+			contentEncoding: "GZIP",
+			want:            body,
+		},
+		{
+			name:            "case-insensitive BASE64",
+			body:            b64Plain,
+			payloadEncoding: "BASE64",
+			want:            body,
+		},
+		{
+			name:            "b64 alias",
+			body:            b64Plain,
+			payloadEncoding: "b64",
+			want:            body,
+		},
+		{
+			name:            "b64 alias + gzip",
+			body:            b64Gzipped,
+			contentEncoding: "gzip",
+			payloadEncoding: "B64",
+			want:            body,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.DecompressWebhookBody(tt.body, tt.contentEncoding, tt.payloadEncoding)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDecompressWebhookBody_RejectsUnsupportedContentEncoding(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+
+	for _, ce := range []string{"br", "brotli", "zstd", "deflate", "compress", "lz4"} {
+		ce := ce
+		t.Run(ce, func(t *testing.T) {
+			got, err := c.DecompressWebhookBody(body, ce, "")
+			require.Error(t, err)
+			require.Nil(t, got)
+			msg := err.Error()
+			assert.Contains(t, msg, "unsupported")
+			assert.Contains(t, msg, "gzip")
+		})
+	}
+}
+
+func TestDecompressWebhookBody_RejectsUnsupportedPayloadEncoding(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+
+	for _, pe := range []string{"hex", "url", "binary"} {
+		pe := pe
+		t.Run(pe, func(t *testing.T) {
+			got, err := c.DecompressWebhookBody(body, "", pe)
+			require.Error(t, err)
+			require.Nil(t, got)
+			assert.Contains(t, err.Error(), "unsupported")
+			assert.Contains(t, err.Error(), "payload_encoding")
+		})
+	}
+}
+
+func TestDecompressWebhookBody_InvalidGzipBytes(t *testing.T) {
+	c := newWebhookTestClient(t)
+
+	got, err := c.DecompressWebhookBody([]byte("not-actually-gzip"), "gzip", "")
+	require.Error(t, err)
+	require.Nil(t, got)
+	assert.Contains(t, err.Error(), "gzip")
+}
+
+func TestDecompressWebhookBody_InvalidBase64Input(t *testing.T) {
+	c := newWebhookTestClient(t)
+
+	got, err := c.DecompressWebhookBody([]byte("!!!not base64!!!"), "", "base64")
+	require.Error(t, err)
+	require.Nil(t, got)
+	assert.Contains(t, err.Error(), "payload_encoding")
+}
+
+func TestVerifyAndDecodeWebhook_Plain(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
+
+	got, err := c.VerifyAndDecodeWebhook(body, string(sig), "", "")
+	require.NoError(t, err)
+	require.Equal(t, body, got)
+}
+
+func TestVerifyAndDecodeWebhook_Gzip(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+	gzipped := gzipBytes(t, body)
+	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
+
+	got, err := c.VerifyAndDecodeWebhook(gzipped, string(sig), "gzip", "")
+	require.NoError(t, err)
+	require.Equal(t, body, got)
+}
+
+func TestVerifyAndDecodeWebhook_Base64Gzip(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+	wrapped := base64Bytes(t, gzipBytes(t, body))
+	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
+
+	got, err := c.VerifyAndDecodeWebhook(wrapped, string(sig), "gzip", "base64")
+	require.NoError(t, err)
+	require.Equal(t, body, got)
+}
+
+func TestVerifyAndDecodeWebhook_SignatureMismatch(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+	wrongSig := hex.EncodeToString(make([]byte, sha256.Size))
+
+	got, err := c.VerifyAndDecodeWebhook(body, wrongSig, "", "")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+	require.Nil(t, got)
+}
+
+func TestVerifyAndDecodeWebhook_RejectsSignatureOverCompressedBytes(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+	gzipped := gzipBytes(t, body)
+	sigOverCompressed := hmacHex(t, []byte(webhookTestAPISecret), gzipped)
+
+	got, err := c.VerifyAndDecodeWebhook(gzipped, string(sigOverCompressed), "gzip", "")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+	require.Nil(t, got)
+}
+
+func TestVerifyAndDecodeWebhook_RejectsSignatureOverWrappedBytes(t *testing.T) {
+	c := newWebhookTestClient(t)
+	body := []byte(webhookTestFixture)
+	wrapped := base64Bytes(t, gzipBytes(t, body))
+	sigOverWrapped := hmacHex(t, []byte(webhookTestAPISecret), wrapped)
+
+	got, err := c.VerifyAndDecodeWebhook(wrapped, string(sigOverWrapped), "gzip", "base64")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+	require.Nil(t, got)
+}
+
+func TestVerifyAndDecodeWebhook_PropagatesDecompressionError(t *testing.T) {
+	c := newWebhookTestClient(t)
+	bogus := []byte("definitely-not-gzip-bytes")
+	sig := hmacHex(t, []byte(webhookTestAPISecret), bogus)
+
+	got, err := c.VerifyAndDecodeWebhook(bogus, string(sig), "gzip", "")
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrInvalidWebhookSignature))
+	require.Nil(t, got)
+	assert.True(t, strings.Contains(err.Error(), "gzip"))
+}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -62,36 +62,36 @@ func TestVerifyWebhook_BackwardCompatibility(t *testing.T) {
 	require.False(t, c.VerifyWebhook([]byte("tampered"), sig))
 }
 
-func TestGunzipPayload(t *testing.T) {
+func TestUngzipPayload(t *testing.T) {
 	body := []byte(webhookTestFixture)
 
 	t.Run("passthrough plain bytes", func(t *testing.T) {
-		got, err := GunzipPayload(body)
+		got, err := UngzipPayload(body)
 		require.NoError(t, err)
 		require.Equal(t, body, got)
 	})
 
 	t.Run("inflates gzip bytes", func(t *testing.T) {
-		got, err := GunzipPayload(gzipBytes(t, body))
+		got, err := UngzipPayload(gzipBytes(t, body))
 		require.NoError(t, err)
 		require.Equal(t, body, got)
 	})
 
 	t.Run("empty input returns empty", func(t *testing.T) {
-		got, err := GunzipPayload([]byte{})
+		got, err := UngzipPayload([]byte{})
 		require.NoError(t, err)
 		require.Equal(t, []byte{}, got)
 	})
 
 	t.Run("short input below magic length", func(t *testing.T) {
-		got, err := GunzipPayload([]byte("ab"))
+		got, err := UngzipPayload([]byte("ab"))
 		require.NoError(t, err)
 		require.Equal(t, []byte("ab"), got)
 	})
 
 	t.Run("gunzipPayload returns ErrInvalidWebhook on corrupt gzip", func(t *testing.T) {
 		bad := append(append([]byte{}, gzipMagic...), 0, 0, 0)
-		got, err := GunzipPayload(bad)
+		got, err := UngzipPayload(bad)
 		require.Error(t, err)
 		require.Nil(t, got)
 		require.True(t, errors.Is(err, ErrInvalidWebhook))
@@ -101,7 +101,7 @@ func TestGunzipPayload(t *testing.T) {
 	t.Run("decompresses helloworld fixture", func(t *testing.T) {
 		compressed, err := base64.StdEncoding.DecodeString("H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA")
 		require.NoError(t, err)
-		got, err := GunzipPayload(compressed)
+		got, err := UngzipPayload(compressed)
 		require.NoError(t, err)
 		require.Equal(t, []byte("helloworld"), got)
 	})

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -28,12 +28,12 @@ func newWebhookTestClient(t *testing.T) *Client {
 	return c
 }
 
-func hmacHex(t *testing.T, secret, body []byte) []byte {
+func hmacHex(t *testing.T, secret, body []byte) string {
 	t.Helper()
 	mac := hmac.New(sha256.New, secret)
 	_, err := mac.Write(body)
 	require.NoError(t, err)
-	return []byte(hex.EncodeToString(mac.Sum(nil)))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 func gzipBytes(t *testing.T, src []byte) []byte {
@@ -46,230 +46,235 @@ func gzipBytes(t *testing.T, src []byte) []byte {
 	return buf.Bytes()
 }
 
-func base64Bytes(t *testing.T, src []byte) []byte {
+func base64String(t *testing.T, src []byte) string {
 	t.Helper()
-	return []byte(base64.StdEncoding.EncodeToString(src))
+	return base64.StdEncoding.EncodeToString(src)
 }
 
 func TestVerifyWebhook_BackwardCompatibility(t *testing.T) {
 	c := newWebhookTestClient(t)
 	body := []byte(webhookTestFixture)
-	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
+	sig := []byte(hmacHex(t, []byte(webhookTestAPISecret), body))
 
 	require.True(t, c.VerifyWebhook(body, sig), "valid signature must verify")
-	require.False(t, c.VerifyWebhook(body, []byte("not-a-valid-hex-signature")), "invalid signature must not verify")
-	require.False(t, c.VerifyWebhook([]byte("tampered"), sig), "tampered body must not verify")
+	require.False(t, c.VerifyWebhook(body, []byte("not-a-valid-hex-signature")))
+	require.False(t, c.VerifyWebhook([]byte("tampered"), sig))
 }
 
-func TestDecompressWebhookBody(t *testing.T) {
-	c := newWebhookTestClient(t)
+func TestUngzipPayload(t *testing.T) {
 	body := []byte(webhookTestFixture)
 
-	gzipped := gzipBytes(t, body)
-	b64Plain := base64Bytes(t, body)
-	b64Gzipped := base64Bytes(t, gzipped)
+	t.Run("passthrough plain bytes", func(t *testing.T) {
+		got, err := UngzipPayload(body)
+		require.NoError(t, err)
+		require.Equal(t, body, got)
+	})
 
-	tests := []struct {
-		name            string
-		body            []byte
-		contentEncoding string
-		payloadEncoding string
-		want            []byte
-	}{
-		{
-			name: "passthrough when both encodings empty",
-			body: body,
-			want: body,
-		},
-		{
-			name:            "passthrough when both encodings whitespace",
-			body:            body,
-			contentEncoding: "  ",
-			payloadEncoding: "\t",
-			want:            body,
-		},
-		{
-			name:            "gzip round-trip",
-			body:            gzipped,
-			contentEncoding: "gzip",
-			want:            body,
-		},
-		{
-			name:            "base64 round-trip without compression",
-			body:            b64Plain,
-			payloadEncoding: "base64",
-			want:            body,
-		},
-		{
-			name:            "base64 + gzip round-trip (SQS / SNS shape)",
-			body:            b64Gzipped,
-			contentEncoding: "gzip",
-			payloadEncoding: "base64",
-			want:            body,
-		},
-		{
-			name:            "case-insensitive GZIP",
-			body:            gzipped,
-			contentEncoding: "GZIP",
-			want:            body,
-		},
-		{
-			name:            "case-insensitive BASE64",
-			body:            b64Plain,
-			payloadEncoding: "BASE64",
-			want:            body,
-		},
-		{
-			name:            "b64 alias",
-			body:            b64Plain,
-			payloadEncoding: "b64",
-			want:            body,
-		},
-		{
-			name:            "b64 alias + gzip",
-			body:            b64Gzipped,
-			contentEncoding: "gzip",
-			payloadEncoding: "B64",
-			want:            body,
-		},
-	}
+	t.Run("inflates gzip bytes", func(t *testing.T) {
+		got, err := UngzipPayload(gzipBytes(t, body))
+		require.NoError(t, err)
+		require.Equal(t, body, got)
+	})
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.DecompressWebhookBody(tt.body, tt.contentEncoding, tt.payloadEncoding)
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
-		})
-	}
+	t.Run("empty input returns empty", func(t *testing.T) {
+		got, err := UngzipPayload([]byte{})
+		require.NoError(t, err)
+		require.Equal(t, []byte{}, got)
+	})
+
+	t.Run("short input below magic length", func(t *testing.T) {
+		got, err := UngzipPayload([]byte("ab"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("ab"), got)
+	})
+
+	t.Run("truncated gzip with magic returns error", func(t *testing.T) {
+		bad := append(append([]byte{}, gzipMagic...), 0, 0, 0)
+		got, err := UngzipPayload(bad)
+		require.Error(t, err)
+		require.Nil(t, got)
+		assert.Contains(t, err.Error(), "gzip")
+	})
 }
 
-func TestDecompressWebhookBody_RejectsUnsupportedContentEncoding(t *testing.T) {
-	c := newWebhookTestClient(t)
+func TestDecodeSqsPayload(t *testing.T) {
 	body := []byte(webhookTestFixture)
 
-	for _, ce := range []string{"br", "brotli", "zstd", "deflate", "compress", "lz4"} {
-		ce := ce
-		t.Run(ce, func(t *testing.T) {
-			got, err := c.DecompressWebhookBody(body, ce, "")
-			require.Error(t, err)
-			require.Nil(t, got)
-			msg := err.Error()
-			assert.Contains(t, msg, "unsupported")
-			assert.Contains(t, msg, "gzip")
-		})
-	}
+	t.Run("base64 only - no compression", func(t *testing.T) {
+		got, err := DecodeSqsPayload(base64String(t, body))
+		require.NoError(t, err)
+		require.Equal(t, body, got)
+	})
+
+	t.Run("base64 plus gzip", func(t *testing.T) {
+		got, err := DecodeSqsPayload(base64String(t, gzipBytes(t, body)))
+		require.NoError(t, err)
+		require.Equal(t, body, got)
+	})
+
+	t.Run("invalid base64 raises", func(t *testing.T) {
+		got, err := DecodeSqsPayload("!!!not-base64!!!")
+		require.Error(t, err)
+		require.Nil(t, got)
+		assert.Contains(t, err.Error(), "base64")
+	})
 }
 
-func TestDecompressWebhookBody_RejectsUnsupportedPayloadEncoding(t *testing.T) {
-	c := newWebhookTestClient(t)
+func TestDecodeSnsPayload(t *testing.T) {
 	body := []byte(webhookTestFixture)
+	wrapped := base64String(t, gzipBytes(t, body))
 
-	for _, pe := range []string{"hex", "url", "binary"} {
-		pe := pe
-		t.Run(pe, func(t *testing.T) {
-			got, err := c.DecompressWebhookBody(body, "", pe)
-			require.Error(t, err)
-			require.Nil(t, got)
-			assert.Contains(t, err.Error(), "unsupported")
-			assert.Contains(t, err.Error(), "payload_encoding")
-		})
-	}
+	sns, err := DecodeSnsPayload(wrapped)
+	require.NoError(t, err)
+	sqs, err := DecodeSqsPayload(wrapped)
+	require.NoError(t, err)
+	require.Equal(t, sqs, sns)
+	require.Equal(t, body, sns)
 }
 
-func TestDecompressWebhookBody_InvalidGzipBytes(t *testing.T) {
-	c := newWebhookTestClient(t)
+func TestVerifySignature(t *testing.T) {
+	body := []byte(webhookTestFixture)
+	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
 
-	got, err := c.DecompressWebhookBody([]byte("not-actually-gzip"), "gzip", "")
-	require.Error(t, err)
-	require.Nil(t, got)
-	assert.Contains(t, err.Error(), "gzip")
+	require.True(t, VerifySignature(body, sig, webhookTestAPISecret))
+	require.False(t, VerifySignature(body, "0000000000000000000000000000000000000000000000000000000000000000", webhookTestAPISecret))
+	require.False(t, VerifySignature(body, sig, "different-secret"))
+
+	compressed := gzipBytes(t, body)
+	sigOverCompressed := hmacHex(t, []byte(webhookTestAPISecret), compressed)
+	require.False(t, VerifySignature(body, sigOverCompressed, webhookTestAPISecret),
+		"signature must be computed over uncompressed bytes")
 }
 
-func TestDecompressWebhookBody_InvalidBase64Input(t *testing.T) {
-	c := newWebhookTestClient(t)
+func TestParseEvent(t *testing.T) {
+	t.Run("known event type", func(t *testing.T) {
+		got, err := ParseEvent([]byte(webhookTestFixture))
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+		require.NotNil(t, got.Message)
+		require.Equal(t, "the quick brown fox", got.Message.Text)
+	})
 
-	got, err := c.DecompressWebhookBody([]byte("!!!not base64!!!"), "", "base64")
-	require.Error(t, err)
-	require.Nil(t, got)
-	assert.Contains(t, err.Error(), "payload_encoding")
+	t.Run("unknown event type still parses", func(t *testing.T) {
+		got, err := ParseEvent([]byte(`{"type":"a.future.event","custom":42}`))
+		require.NoError(t, err)
+		require.Equal(t, EventType("a.future.event"), got.Type)
+	})
+
+	t.Run("malformed json returns error", func(t *testing.T) {
+		got, err := ParseEvent([]byte("not json"))
+		require.Error(t, err)
+		require.Nil(t, got)
+	})
 }
 
-func TestVerifyAndDecodeWebhook_Plain(t *testing.T) {
+func TestVerifyAndParseWebhook(t *testing.T) {
 	c := newWebhookTestClient(t)
 	body := []byte(webhookTestFixture)
 	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
 
-	got, err := c.VerifyAndDecodeWebhook(body, string(sig), "", "")
-	require.NoError(t, err)
-	require.Equal(t, body, got)
+	t.Run("plain body via package", func(t *testing.T) {
+		got, err := VerifyAndParseWebhook(body, sig, webhookTestAPISecret)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("gzip body via package", func(t *testing.T) {
+		got, err := VerifyAndParseWebhook(gzipBytes(t, body), sig, webhookTestAPISecret)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("plain body via client", func(t *testing.T) {
+		got, err := c.VerifyAndParseWebhook(body, sig)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("gzip body via client", func(t *testing.T) {
+		got, err := c.VerifyAndParseWebhook(gzipBytes(t, body), sig)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("signature mismatch returns ErrInvalidWebhookSignature", func(t *testing.T) {
+		got, err := c.VerifyAndParseWebhook(body, strings.Repeat("0", 64))
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.Nil(t, got)
+	})
+
+	t.Run("signature over compressed bytes rejected", func(t *testing.T) {
+		compressed := gzipBytes(t, body)
+		sigOverCompressed := hmacHex(t, []byte(webhookTestAPISecret), compressed)
+		got, err := c.VerifyAndParseWebhook(compressed, sigOverCompressed)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.Nil(t, got)
+	})
+
+	t.Run("propagates decompression error", func(t *testing.T) {
+		bogus := append(append([]byte{}, gzipMagic...), []byte("garbage")...)
+		got, err := c.VerifyAndParseWebhook(bogus, sig)
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.Nil(t, got)
+	})
 }
 
-func TestVerifyAndDecodeWebhook_Gzip(t *testing.T) {
+func TestVerifyAndParseSqs(t *testing.T) {
 	c := newWebhookTestClient(t)
 	body := []byte(webhookTestFixture)
-	gzipped := gzipBytes(t, body)
 	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
 
-	got, err := c.VerifyAndDecodeWebhook(gzipped, string(sig), "gzip", "")
-	require.NoError(t, err)
-	require.Equal(t, body, got)
+	t.Run("base64 only via client", func(t *testing.T) {
+		got, err := c.VerifyAndParseSqs(base64String(t, body), sig)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("base64 plus gzip via client", func(t *testing.T) {
+		wrapped := base64String(t, gzipBytes(t, body))
+		got, err := c.VerifyAndParseSqs(wrapped, sig)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("via package", func(t *testing.T) {
+		wrapped := base64String(t, gzipBytes(t, body))
+		got, err := VerifyAndParseSqs(wrapped, sig, webhookTestAPISecret)
+		require.NoError(t, err)
+		require.Equal(t, EventMessageNew, got.Type)
+	})
+
+	t.Run("signature over wrapped bytes rejected", func(t *testing.T) {
+		wrapped := base64String(t, gzipBytes(t, body))
+		sigOverWrapped := hmacHex(t, []byte(webhookTestAPISecret), []byte(wrapped))
+		got, err := c.VerifyAndParseSqs(wrapped, sigOverWrapped)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.Nil(t, got)
+	})
+
+	t.Run("invalid base64 surfaced as error", func(t *testing.T) {
+		got, err := c.VerifyAndParseSqs("!!!not-base64!!!", sig)
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrInvalidWebhookSignature))
+		require.Nil(t, got)
+	})
 }
 
-func TestVerifyAndDecodeWebhook_Base64Gzip(t *testing.T) {
+func TestVerifyAndParseSns(t *testing.T) {
 	c := newWebhookTestClient(t)
 	body := []byte(webhookTestFixture)
-	wrapped := base64Bytes(t, gzipBytes(t, body))
 	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
+	wrapped := base64String(t, gzipBytes(t, body))
 
-	got, err := c.VerifyAndDecodeWebhook(wrapped, string(sig), "gzip", "base64")
+	got, err := c.VerifyAndParseSns(wrapped, sig)
 	require.NoError(t, err)
-	require.Equal(t, body, got)
-}
+	require.Equal(t, EventMessageNew, got.Type)
 
-func TestVerifyAndDecodeWebhook_SignatureMismatch(t *testing.T) {
-	c := newWebhookTestClient(t)
-	body := []byte(webhookTestFixture)
-	wrongSig := hex.EncodeToString(make([]byte, sha256.Size))
-
-	got, err := c.VerifyAndDecodeWebhook(body, wrongSig, "", "")
-	require.Error(t, err)
-	require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
-	require.Nil(t, got)
-}
-
-func TestVerifyAndDecodeWebhook_RejectsSignatureOverCompressedBytes(t *testing.T) {
-	c := newWebhookTestClient(t)
-	body := []byte(webhookTestFixture)
-	gzipped := gzipBytes(t, body)
-	sigOverCompressed := hmacHex(t, []byte(webhookTestAPISecret), gzipped)
-
-	got, err := c.VerifyAndDecodeWebhook(gzipped, string(sigOverCompressed), "gzip", "")
-	require.Error(t, err)
-	require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
-	require.Nil(t, got)
-}
-
-func TestVerifyAndDecodeWebhook_RejectsSignatureOverWrappedBytes(t *testing.T) {
-	c := newWebhookTestClient(t)
-	body := []byte(webhookTestFixture)
-	wrapped := base64Bytes(t, gzipBytes(t, body))
-	sigOverWrapped := hmacHex(t, []byte(webhookTestAPISecret), wrapped)
-
-	got, err := c.VerifyAndDecodeWebhook(wrapped, string(sigOverWrapped), "gzip", "base64")
-	require.Error(t, err)
-	require.True(t, errors.Is(err, ErrInvalidWebhookSignature))
-	require.Nil(t, got)
-}
-
-func TestVerifyAndDecodeWebhook_PropagatesDecompressionError(t *testing.T) {
-	c := newWebhookTestClient(t)
-	bogus := []byte("definitely-not-gzip-bytes")
-	sig := hmacHex(t, []byte(webhookTestAPISecret), bogus)
-
-	got, err := c.VerifyAndDecodeWebhook(bogus, string(sig), "gzip", "")
-	require.Error(t, err)
-	require.False(t, errors.Is(err, ErrInvalidWebhookSignature))
-	require.Nil(t, got)
-	assert.True(t, strings.Contains(err.Error(), "gzip"))
+	pkg, err := VerifyAndParseSns(wrapped, sig, webhookTestAPISecret)
+	require.NoError(t, err)
+	require.Equal(t, got.Type, pkg.Type)
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -62,39 +62,47 @@ func TestVerifyWebhook_BackwardCompatibility(t *testing.T) {
 	require.False(t, c.VerifyWebhook([]byte("tampered"), sig))
 }
 
-func TestUngzipPayload(t *testing.T) {
+func TestGunzipPayload(t *testing.T) {
 	body := []byte(webhookTestFixture)
 
 	t.Run("passthrough plain bytes", func(t *testing.T) {
-		got, err := UngzipPayload(body)
+		got, err := GunzipPayload(body)
 		require.NoError(t, err)
 		require.Equal(t, body, got)
 	})
 
 	t.Run("inflates gzip bytes", func(t *testing.T) {
-		got, err := UngzipPayload(gzipBytes(t, body))
+		got, err := GunzipPayload(gzipBytes(t, body))
 		require.NoError(t, err)
 		require.Equal(t, body, got)
 	})
 
 	t.Run("empty input returns empty", func(t *testing.T) {
-		got, err := UngzipPayload([]byte{})
+		got, err := GunzipPayload([]byte{})
 		require.NoError(t, err)
 		require.Equal(t, []byte{}, got)
 	})
 
 	t.Run("short input below magic length", func(t *testing.T) {
-		got, err := UngzipPayload([]byte("ab"))
+		got, err := GunzipPayload([]byte("ab"))
 		require.NoError(t, err)
 		require.Equal(t, []byte("ab"), got)
 	})
 
 	t.Run("truncated gzip with magic returns error", func(t *testing.T) {
 		bad := append(append([]byte{}, gzipMagic...), 0, 0, 0)
-		got, err := UngzipPayload(bad)
+		got, err := GunzipPayload(bad)
 		require.Error(t, err)
 		require.Nil(t, got)
 		assert.Contains(t, err.Error(), "gzip")
+	})
+
+	t.Run("decompresses helloworld fixture", func(t *testing.T) {
+		compressed, err := base64.StdEncoding.DecodeString("H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA")
+		require.NoError(t, err)
+		got, err := GunzipPayload(compressed)
+		require.NoError(t, err)
+		require.Equal(t, []byte("helloworld"), got)
 	})
 }
 
@@ -118,6 +126,18 @@ func TestDecodeSqsPayload(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, got)
 		assert.Contains(t, err.Error(), "base64")
+	})
+
+	t.Run("helloworld base64 fixture", func(t *testing.T) {
+		got, err := DecodeSqsPayload("aGVsbG93b3JsZA==")
+		require.NoError(t, err)
+		require.Equal(t, []byte("helloworld"), got)
+	})
+
+	t.Run("helloworld base64+gzip fixture", func(t *testing.T) {
+		got, err := DecodeSqsPayload("H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA")
+		require.NoError(t, err)
+		require.Equal(t, []byte("helloworld"), got)
 	})
 }
 

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -306,43 +306,34 @@ func TestVerifyAndParseWebhook(t *testing.T) {
 	})
 }
 
-func TestVerifyAndParseSqs(t *testing.T) {
+func TestParseSqs(t *testing.T) {
 	c := newWebhookTestClient(t)
 	body := []byte(webhookTestFixture)
-	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
 
 	t.Run("base64 only via client", func(t *testing.T) {
-		got, err := c.VerifyAndParseSqs(base64String(t, body), sig)
+		got, err := c.ParseSqs(base64String(t, body))
 		require.NoError(t, err)
 		require.Equal(t, EventMessageNew, got.Type)
+		require.NotNil(t, got.Message)
+		require.Equal(t, "the quick brown fox", got.Message.Text)
 	})
 
 	t.Run("base64 plus gzip via client", func(t *testing.T) {
 		wrapped := base64String(t, gzipBytes(t, body))
-		got, err := c.VerifyAndParseSqs(wrapped, sig)
+		got, err := c.ParseSqs(wrapped)
 		require.NoError(t, err)
 		require.Equal(t, EventMessageNew, got.Type)
 	})
 
 	t.Run("via package", func(t *testing.T) {
 		wrapped := base64String(t, gzipBytes(t, body))
-		got, err := VerifyAndParseSqs(wrapped, sig, webhookTestAPISecret)
+		got, err := ParseSqs(wrapped)
 		require.NoError(t, err)
 		require.Equal(t, EventMessageNew, got.Type)
 	})
 
-	t.Run("signature over wrapped bytes rejected", func(t *testing.T) {
-		wrapped := base64String(t, gzipBytes(t, body))
-		sigOverWrapped := hmacHex(t, []byte(webhookTestAPISecret), []byte(wrapped))
-		got, err := c.VerifyAndParseSqs(wrapped, sigOverWrapped)
-		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrInvalidWebhook))
-		assert.Contains(t, err.Error(), "signature mismatch")
-		require.Nil(t, got)
-	})
-
 	t.Run("invalid base64 surfaced as ErrInvalidWebhook", func(t *testing.T) {
-		got, err := c.VerifyAndParseSqs("!!!not-base64!!!", sig)
+		got, err := c.ParseSqs("!!!not-base64!!!")
 		require.Error(t, err)
 		require.True(t, errors.Is(err, ErrInvalidWebhook))
 		assert.Contains(t, err.Error(), "invalid base64 encoding")
@@ -350,160 +341,35 @@ func TestVerifyAndParseSqs(t *testing.T) {
 	})
 }
 
-func TestVerifyAndParseSns(t *testing.T) {
+func TestParseSns(t *testing.T) {
 	c := newWebhookTestClient(t)
 	body := []byte(webhookTestFixture)
-	sig := hmacHex(t, []byte(webhookTestAPISecret), body)
 	wrapped := base64String(t, gzipBytes(t, body))
 
 	t.Run("pre-extracted message backward compat", func(t *testing.T) {
-		got, err := c.VerifyAndParseSns(wrapped, sig)
+		got, err := c.ParseSns(wrapped)
 		require.NoError(t, err)
 		require.Equal(t, EventMessageNew, got.Type)
 
-		pkg, err := VerifyAndParseSns(wrapped, sig, webhookTestAPISecret)
+		pkg, err := ParseSns(wrapped)
 		require.NoError(t, err)
 		require.Equal(t, got.Type, pkg.Type)
 	})
 
 	t.Run("full SNS HTTP notification envelope", func(t *testing.T) {
 		envelope := snsEnvelope(t, wrapped)
-		got, err := c.VerifyAndParseSns(envelope, sig)
-		require.NoError(t, err)
-		require.Equal(t, EventMessageNew, got.Type)
-	})
-
-	t.Run("envelope signature verifies against inner payload", func(t *testing.T) {
-		envelope := snsEnvelope(t, wrapped)
-		envelopeSig := hmacHex(t, []byte(webhookTestAPISecret), []byte(envelope))
-		got, err := c.VerifyAndParseSns(envelope, envelopeSig)
-		require.Error(t, err)
-		require.True(t, errors.Is(err, ErrInvalidWebhook))
-		assert.Contains(t, err.Error(), "signature mismatch")
-		require.Nil(t, got)
-	})
-}
-
-func TestVerifyAndParseSqs_NoSignature(t *testing.T) {
-	body := []byte(webhookTestFixture)
-
-	t.Run("plain base64 body", func(t *testing.T) {
-		got, err := VerifyAndParseSqs(base64String(t, body), "", "")
+		got, err := c.ParseSns(envelope)
 		require.NoError(t, err)
 		require.Equal(t, EventMessageNew, got.Type)
 		require.NotNil(t, got.Message)
 		require.Equal(t, "the quick brown fox", got.Message.Text)
 	})
 
-	t.Run("base64 plus gzip body", func(t *testing.T) {
-		got, err := VerifyAndParseSqs(base64String(t, gzipBytes(t, body)), "", "")
-		require.NoError(t, err)
-		require.Equal(t, EventMessageNew, got.Type)
-	})
-
-	t.Run("invalid base64 still surfaces as ErrInvalidWebhook", func(t *testing.T) {
-		got, err := VerifyAndParseSqs("!!!not-base64!!!", "", "")
+	t.Run("invalid base64 surfaced as ErrInvalidWebhook", func(t *testing.T) {
+		got, err := c.ParseSns("!!!not-base64!!!")
 		require.Error(t, err)
-		require.Nil(t, got)
 		require.True(t, errors.Is(err, ErrInvalidWebhook))
 		assert.Contains(t, err.Error(), "invalid base64 encoding")
-	})
-}
-
-func TestVerifyAndParseSns_NoSignature(t *testing.T) {
-	body := []byte(webhookTestFixture)
-	wrapped := base64String(t, gzipBytes(t, body))
-
-	t.Run("pre-extracted Message", func(t *testing.T) {
-		got, err := VerifyAndParseSns(wrapped, "", "")
-		require.NoError(t, err)
-		require.Equal(t, EventMessageNew, got.Type)
-	})
-
-	t.Run("full SNS HTTP notification envelope", func(t *testing.T) {
-		envelope := snsEnvelope(t, wrapped)
-		got, err := VerifyAndParseSns(envelope, "", "")
-		require.NoError(t, err)
-		require.Equal(t, EventMessageNew, got.Type)
-		require.NotNil(t, got.Message)
-		require.Equal(t, "the quick brown fox", got.Message.Text)
-	})
-}
-
-func TestClient_VerifyAndParseSqs_NoSignature(t *testing.T) {
-	c := newWebhookTestClient(t)
-	body := []byte(webhookTestFixture)
-	wrapped := base64String(t, gzipBytes(t, body))
-
-	t.Run("zero signature args skips verification", func(t *testing.T) {
-		got, err := c.VerifyAndParseSqs(wrapped)
-		require.NoError(t, err)
-		require.Equal(t, EventMessageNew, got.Type)
-	})
-
-	t.Run("one signature arg verifies against client secret", func(t *testing.T) {
-		sig := hmacHex(t, []byte(webhookTestAPISecret), body)
-		got, err := c.VerifyAndParseSqs(wrapped, sig)
-		require.NoError(t, err)
-		require.Equal(t, EventMessageNew, got.Type)
-	})
-
-	t.Run("more than one signature arg is rejected", func(t *testing.T) {
-		got, err := c.VerifyAndParseSqs(wrapped, "sig-a", "sig-b")
-		require.Error(t, err)
 		require.Nil(t, got)
-		require.True(t, errors.Is(err, ErrInvalidWebhook))
-		assert.Contains(t, err.Error(), "accepts at most one signature argument")
 	})
-
-	t.Run("variadic form on Sns mirrors Sqs", func(t *testing.T) {
-		envelope := snsEnvelope(t, wrapped)
-		got, err := c.VerifyAndParseSns(envelope)
-		require.NoError(t, err)
-		require.Equal(t, EventMessageNew, got.Type)
-
-		got, err = c.VerifyAndParseSns(envelope, "sig-a", "sig-b")
-		require.Error(t, err)
-		require.Nil(t, got)
-		require.True(t, errors.Is(err, ErrInvalidWebhook))
-		assert.Contains(t, err.Error(), "accepts at most one signature argument")
-	})
-}
-
-func TestVerifyAndParseSqs_RejectsPartialCreds(t *testing.T) {
-	body := []byte(webhookTestFixture)
-	wrapped := base64String(t, gzipBytes(t, body))
-	envelope := snsEnvelope(t, wrapped)
-
-	cases := []struct {
-		name string
-		call func() (*Event, error)
-	}{
-		{
-			name: "sqs signature only",
-			call: func() (*Event, error) { return VerifyAndParseSqs(wrapped, "sig", "") },
-		},
-		{
-			name: "sqs secret only",
-			call: func() (*Event, error) { return VerifyAndParseSqs(wrapped, "", "sec") },
-		},
-		{
-			name: "sns signature only",
-			call: func() (*Event, error) { return VerifyAndParseSns(envelope, "sig", "") },
-		},
-		{
-			name: "sns secret only",
-			call: func() (*Event, error) { return VerifyAndParseSns(envelope, "", "sec") },
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := tc.call()
-			require.Error(t, err)
-			require.Nil(t, got)
-			require.True(t, errors.Is(err, ErrInvalidWebhook))
-			assert.Contains(t, err.Error(), "signature and secret must both be provided")
-		})
-	}
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -62,36 +62,36 @@ func TestVerifyWebhook_BackwardCompatibility(t *testing.T) {
 	require.False(t, c.VerifyWebhook([]byte("tampered"), sig))
 }
 
-func TestUngzipPayload(t *testing.T) {
+func TestGunzipPayload(t *testing.T) {
 	body := []byte(webhookTestFixture)
 
 	t.Run("passthrough plain bytes", func(t *testing.T) {
-		got, err := UngzipPayload(body)
+		got, err := GunzipPayload(body)
 		require.NoError(t, err)
 		require.Equal(t, body, got)
 	})
 
 	t.Run("inflates gzip bytes", func(t *testing.T) {
-		got, err := UngzipPayload(gzipBytes(t, body))
+		got, err := GunzipPayload(gzipBytes(t, body))
 		require.NoError(t, err)
 		require.Equal(t, body, got)
 	})
 
 	t.Run("empty input returns empty", func(t *testing.T) {
-		got, err := UngzipPayload([]byte{})
+		got, err := GunzipPayload([]byte{})
 		require.NoError(t, err)
 		require.Equal(t, []byte{}, got)
 	})
 
 	t.Run("short input below magic length", func(t *testing.T) {
-		got, err := UngzipPayload([]byte("ab"))
+		got, err := GunzipPayload([]byte("ab"))
 		require.NoError(t, err)
 		require.Equal(t, []byte("ab"), got)
 	})
 
 	t.Run("gunzipPayload returns ErrInvalidWebhook on corrupt gzip", func(t *testing.T) {
 		bad := append(append([]byte{}, gzipMagic...), 0, 0, 0)
-		got, err := UngzipPayload(bad)
+		got, err := GunzipPayload(bad)
 		require.Error(t, err)
 		require.Nil(t, got)
 		require.True(t, errors.Is(err, ErrInvalidWebhook))
@@ -101,7 +101,7 @@ func TestUngzipPayload(t *testing.T) {
 	t.Run("decompresses helloworld fixture", func(t *testing.T) {
 		compressed, err := base64.StdEncoding.DecodeString("H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA")
 		require.NoError(t, err)
-		got, err := UngzipPayload(compressed)
+		got, err := GunzipPayload(compressed)
 		require.NoError(t, err)
 		require.Equal(t, []byte("helloworld"), got)
 	})


### PR DESCRIPTION
## Summary

Adds first-class support for **gzip-compressed webhook payloads** (HTTP webhooks, SQS, SNS) and exposes a stable `VerifyAndParse*` API that mirrors the cross-SDK contract published in [Webhooks Overview](https://getstream.io/chat/docs/node/webhooks_overview/#handling-the-webhook).

### New public API

Primitives (in `webhook.go`, intended to be composable):

- `GunzipPayload(body) ([]byte, error)` — gzip-magic-byte detection, no-op when not compressed
- `DecodeSqsPayload(body) ([]byte, error)` — base64 decode then gunzip-if-magic
- `DecodeSnsPayload(notificationBody) ([]byte, error)` — JSON-parse the SNS HTTP notification envelope, extract the inner `Message`, then run the SQS pipeline. Falls through to a pre-extracted `Message` string when the input is not a JSON envelope
- `VerifySignature(body, signature, secret) error` — HMAC-SHA256 over the **uncompressed** body, with a constant-time comparison (matters for the HTTP webhook path where the `X-Signature` header is exposed publicly; SQS / SNS deliveries arrive over AWS-internal transports where timing-attack resistance is not strictly required). Returns a non-nil error wrapping `stream.ErrInvalidWebhook` on mismatch — see Unified error handling below.
- `ParseEvent(payload) (*Event, error)` — JSON → typed `*Event`

Composites (return a typed `*Event`):

- `VerifyAndParseWebhook(body, signature, secret) (*Event, error)`
- `VerifyAndParseSqs(body, signature, secret) (*Event, error)`
- `VerifyAndParseSns(body, signature, secret) (*Event, error)`

Client-bound versions on `*Client` use the configured app secret automatically.

### Backwards compatibility

`Client.VerifyWebhook` is preserved and delegates to `VerifySignature`. Existing callers continue to work unchanged for plain (uncompressed) bodies.

### Unified error handling

Per cross-SDK coordination (mogita's review across the 6 sibling SDK PRs), every webhook failure path now terminates at a **single sentinel error — `stream.ErrInvalidWebhook`** so customers only need one error-handling arm. The message text identifies which failure mode fired so callers that want to differentiate (security logging, retry policy) can filter on substring:

| Failure mode      | Message                       |
| ----------------- | ----------------------------- |
| Signature mismatch | `signature mismatch`         |
| Base64 decode      | `invalid base64 encoding`    |
| Gzip decompression | `gzip decompression failed`  |
| JSON parse         | `invalid JSON payload`       |

Use `errors.Is(err, stream.ErrInvalidWebhook)` for the unified check; the inner cause (when present) is preserved via `%w` wrapping. `VerifySignature` now returns `error` (was `bool`) so it surfaces the mode-specific message; the legacy `Client.VerifyWebhook` (bool return, constant-time `hmac.Equal`) is untouched.

### Tests

`webhook_test.go` covers plain / gzip / base64 / base64+gzip payloads, signature mismatches, malformed bytes, JSON parsing into `*Event`, and a backwards-compat path for `Client.VerifyWebhook`. Linked Linear ticket: [CHA-3071](https://linear.app/stream/issue/CHA-3071/compress-webhook-payloads).



### Golden test fixtures (Tommaso)

Added shared reference fixtures to the test suite so future SDKs can sanity-check decoders against the same payloads:

```
aGVsbG93b3JsZA==                          -> helloworld   (base64)
H4sIAGrYAWoAA8tIzcnJL88vykkBAK0g6/kKAAAA -> helloworld   (base64 + gzip)
```
## Test plan

- [x] `go vet ./...` clean
- [x] `go test -c .` (test binary compiles clean)
- [ ] Full `go test ./...` runs in CI (package `init()` requires `STREAM_KEY` / `STREAM_SECRET`)




